### PR TITLE
Propagate derived traits for wrapper types

### DIFF
--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
@@ -1,19 +1,19 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_ipv4_tuple {
     pub src_addr: u32,
     pub dst_addr: u32,
     pub __bindgen_anon_1: rte_ipv4_tuple__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_ipv4_tuple__bindgen_ty_1 {
     pub __bindgen_anon_1: rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
     pub sctp_tag: u32,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
@@ -77,20 +77,20 @@ impl Default for rte_ipv4_tuple {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_ipv6_tuple {
     pub src_addr: [u8; 16usize],
     pub dst_addr: [u8; 16usize],
     pub __bindgen_anon_1: rte_ipv6_tuple__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_ipv6_tuple__bindgen_ty_1 {
     pub __bindgen_anon_1: rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
     pub sctp_tag: u32,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
@@ -155,7 +155,7 @@ impl Default for rte_ipv6_tuple {
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_thash_tuple {
     pub v4: rte_ipv4_tuple,
     pub v6: rte_ipv6_tuple,

--- a/bindgen-tests/tests/expectations/tests/381-decltype-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/381-decltype-alias.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct std_allocator_traits {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/accessors.rs
+++ b/bindgen-tests/tests/expectations/tests/accessors.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SomeAccessors {
     pub mNoAccessor: ::std::os::raw::c_int,
     /// <div rustbindgen accessor></div>
@@ -51,7 +51,7 @@ impl SomeAccessors {
 }
 /// <div rustbindgen accessor></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AllAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
@@ -87,7 +87,7 @@ impl AllAccessors {
 }
 /// <div rustbindgen accessor="unsafe"></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AllUnsafeAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
@@ -125,7 +125,7 @@ impl AllUnsafeAccessors {
 }
 /// <div rustbindgen accessor></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ContradictAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     /// <div rustbindgen accessor="false"></div>
@@ -180,7 +180,7 @@ impl ContradictAccessors {
 }
 /// <div rustbindgen accessor replaces="Replaced"></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Replaced {
     pub mAccessor: ::std::os::raw::c_int,
 }
@@ -204,7 +204,7 @@ impl Replaced {
 }
 /// <div rustbindgen accessor></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Wrapper {
     pub mReplaced: Replaced,
 }

--- a/bindgen-tests/tests/expectations/tests/alias_comments.rs
+++ b/bindgen-tests/tests/expectations/tests/alias_comments.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// This is Struct
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Struct {
     /// This is field
     pub field: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -8,7 +8,7 @@ unsafe extern "C" {
     pub static mut someVar: ::std::os::raw::c_int;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct someClass {
     pub _address: u8,
 }
@@ -35,7 +35,7 @@ unsafe extern "C" {
     pub fn foo_NamespacedFunction();
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StructWithAllowlistedDefinition {
     pub other: *mut StructWithAllowlistedFwdDecl,
 }
@@ -61,7 +61,7 @@ impl Default for StructWithAllowlistedDefinition {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct StructWithAllowlistedFwdDecl {
     pub b: ::std::os::raw::c_int,
 }
@@ -78,7 +78,7 @@ const _: () = {
     ][::std::mem::offset_of!(StructWithAllowlistedFwdDecl, b) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AllowlistMe {
     pub foo: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
@@ -10,7 +10,7 @@ pub mod root {
             #[allow(unused_imports)]
             use self::super::super::super::root;
             #[repr(C)]
-            #[derive(Debug, Default, Copy, Clone)]
+            #[derive(Clone, Copy, Debug, Default)]
             pub struct Helper {
                 pub _address: u8,
             }

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
@@ -10,7 +10,7 @@ pub mod root {
             #[allow(unused_imports)]
             use self::super::super::super::root;
             #[repr(C)]
-            #[derive(Debug, Default, Copy, Clone)]
+            #[derive(Clone, Copy, Debug, Default)]
             pub struct Helper {
                 pub _address: u8,
             }
@@ -21,7 +21,7 @@ pub mod root {
             };
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Test {
             pub helper: root::outer::inner::Helper,
         }

--- a/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct AllowlistMe<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: ::std::os::raw::c_int,
     pub bar: AllowlistMe_Inner<T>,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct AllowlistMe_Inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub bar: T,

--- a/bindgen-tests/tests/expectations/tests/allowlist_item.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_item.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const FooDefault: u32 = 0;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub field: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoHash {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AllowlistMe {
     pub a: NoHash,
 }

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoPartialEq {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AllowlistMe {
     pub a: NoPartialEq,
 }

--- a/bindgen-tests/tests/expectations/tests/annotation_hide.rs
+++ b/bindgen-tests/tests/expectations/tests/annotation_hide.rs
@@ -2,7 +2,7 @@
 /// <div rustbindgen opaque></div>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct D {
     pub _bindgen_opaque_blob: u32,
 }
@@ -12,7 +12,7 @@ const _: () = {
     ["Alignment of D"][::std::mem::align_of::<D>() - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NotAnnotated {
     pub f: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
+++ b/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union color {
     pub u1: color__bindgen_ty_1,
     pub u2: color__bindgen_ty_2,
     pub v3: [::std::os::raw::c_uchar; 3usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct color__bindgen_ty_1 {
     pub r: ::std::os::raw::c_uchar,
     pub g: ::std::os::raw::c_uchar,
@@ -32,7 +32,7 @@ const _: () = {
     ][::std::mem::offset_of!(color__bindgen_ty_1, b) - 2usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct color__bindgen_ty_2 {
     pub y: ::std::os::raw::c_uchar,
     pub u: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/anon_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Test {
     pub foo: ::std::os::raw::c_int,
     pub bar: f32,

--- a/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct DataType {
     pub _address: u8,
 }
@@ -19,7 +19,7 @@ pub enum DataType__bindgen_ty_1 {
     generic_type = 0,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
@@ -1,16 +1,16 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct s {
     pub u: s__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union s__bindgen_ty_1 {
     pub field: s__bindgen_ty_1_inner,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct s__bindgen_ty_1_inner {
     pub b: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/anonymous-template-types.rs
+++ b/bindgen-tests/tests/expectations/tests/anonymous-template-types.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Foo<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t_member: T,
@@ -15,12 +15,12 @@ impl<T> Default for Foo<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Bar {
     pub member: ::std::os::raw::c_char,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Quux<V> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
     pub v_member: V,
@@ -35,7 +35,7 @@ impl<V> Default for Quux<V> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Lobo {
     pub also_member: ::std::os::raw::c_char,
 }

--- a/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// This should get an `_address` byte.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Empty {
     pub _address: u8,
 }
@@ -13,7 +13,7 @@ const _: () = {
 /** This should not get an `_address` byte, since each `Empty` gets one, meaning
  that this object is addressable.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct HasArrayOfEmpty {
     pub empties: [Empty; 10usize],
 }

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/auto.rs
+++ b/bindgen-tests/tests/expectations/tests/auto.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
@@ -11,7 +11,7 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct std_char_traits {
     pub _address: u8,
 }
@@ -14,7 +14,7 @@ impl Default for std_char_traits {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __gnu_cxx_char_traits {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/base-to-derived.rs
+++ b/bindgen-tests/tests/expectations/tests/base-to-derived.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct false_type {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Copy, Clone)]
+        #[derive(Clone, Copy)]
         pub union Bar {
             pub foo: ::std::os::raw::c_int,
             pub bar: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct MuchBitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize]>,
 }
@@ -1370,7 +1376,7 @@ impl MuchBitfield {
         m31: ::std::os::raw::c_char,
         m32: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 5usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 5usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 5usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
@@ -101,7 +101,7 @@ impl ::std::ops::BitAndAssign for _bindgen_ty_1 {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct _bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Dummy {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,13 +145,15 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct HasBigBitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
@@ -195,7 +201,7 @@ impl HasBigBitfield {
     }
     #[inline]
     pub fn new_bitfield_1(x: i128) -> __BindgenBitfieldUnit<[u8; 16usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 16usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -210,7 +216,7 @@ impl HasBigBitfield {
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct HasTwoBigBitfields {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
@@ -298,7 +304,7 @@ impl HasTwoBigBitfields {
     }
     #[inline]
     pub fn new_bitfield_1(x: i128, y: i128) -> __BindgenBitfieldUnit<[u8; 16usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 16usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test {
     pub foo: u64,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -226,7 +232,7 @@ impl Test {
     }
     #[inline]
     pub fn new_bitfield_1(x: u64, y: u64) -> __BindgenBitfieldUnit<[u8; 8usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 8usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -212,7 +218,7 @@ impl Foo {
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield-template.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-template.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member: T,
@@ -199,7 +205,7 @@ impl<T> foo<T> {
     }
     #[inline]
     pub fn new_bitfield_1(b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _bindgen_align: [u32; 0],
     pub x: ::std::os::raw::c_uchar,
@@ -534,7 +540,7 @@ impl A {
         b9: ::std::os::raw::c_uint,
         b10: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -629,7 +635,7 @@ impl A {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -717,7 +723,7 @@ impl B {
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -740,7 +746,7 @@ impl B {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub x: ::std::os::raw::c_uchar,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -831,7 +837,7 @@ impl C {
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -854,7 +860,7 @@ impl C {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Date1 {
     pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
@@ -1017,7 +1023,7 @@ impl Date1 {
         nMonth: ::std::os::raw::c_ushort,
         nYear: ::std::os::raw::c_ushort,
     ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -1058,7 +1064,7 @@ impl Date1 {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Date2 {
     pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -1257,7 +1263,7 @@ impl Date2 {
         nYear: ::std::os::raw::c_ushort,
         byte: ::std::os::raw::c_uchar,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -1307,7 +1313,7 @@ impl Date2 {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Date3 {
     pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
@@ -1471,7 +1477,7 @@ impl Date3 {
         nMonth: ::std::os::raw::c_ushort,
         nYear: ::std::os::raw::c_ushort,
     ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -1,16 +1,18 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(not(target_os = "windows"))]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -33,12 +35,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -60,12 +62,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -90,6 +92,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -128,6 +131,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -142,7 +146,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -155,7 +161,7 @@ pub enum MyEnum {
     FOUR = 3,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct TaggedPtr {
     pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -252,7 +258,7 @@ impl TaggedPtr {
         tag: MyEnum,
         ptr: ::std::os::raw::c_long,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 8usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield_comma_separated_derives.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_comma_separated_derives.rs
@@ -1,0 +1,433 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+#[allow(unused_qualifications)]
+impl<Storage> __BindgenBitfieldUnit<Storage> {
+    #[inline]
+    pub const fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+#[allow(unused_qualifications)]
+impl<Storage> __BindgenBitfieldUnit<Storage>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
+    #[inline]
+    fn extract_bit(byte: u8, index: usize) -> bool {
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        byte & mask == mask
+    }
+    #[inline]
+    pub fn get_bit(&self, index: usize) -> bool {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = self.storage.as_ref()[byte_index];
+        Self::extract_bit(byte, index)
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
+        debug_assert!(index / 8 < core::mem::size_of::<Storage>());
+        let byte_index = index / 8;
+        let byte = unsafe {
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
+        };
+        Self::extract_bit(byte, index)
+    }
+    #[inline]
+    fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        if val { byte | mask } else { byte & !mask }
+    }
+    #[inline]
+    pub fn set_bit(&mut self, index: usize, val: bool) {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = &mut self.storage.as_mut()[byte_index];
+        *byte = Self::change_bit(*byte, index, val);
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
+        debug_assert!(index / 8 < core::mem::size_of::<Storage>());
+        let byte_index = index / 8;
+        let byte = unsafe {
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
+        };
+        unsafe { *byte = Self::change_bit(*byte, index, val) };
+    }
+    #[inline]
+    pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if self.get_bit(i + bit_offset) {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= core::mem::size_of::<Storage>(),
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if unsafe { Self::raw_get_bit(this, i + bit_offset) } {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            self.set_bit(index + bit_offset, val_bit_is_set);
+        }
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= core::mem::size_of::<Storage>(),
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
+        }
+    }
+}
+/// <div rustbindgen derive="PartialEq,Eq"></div>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct first_bitfield_struct {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of first_bitfield_struct",
+    ][::std::mem::size_of::<first_bitfield_struct>() - 4usize];
+    [
+        "Alignment of first_bitfield_struct",
+    ][::std::mem::align_of::<first_bitfield_struct>() - 4usize];
+};
+impl first_bitfield_struct {
+    #[inline]
+    pub fn a(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 1u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn b(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 2u8) as u32) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 1usize, 2u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                2u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn c(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 3u8) as u32) }
+    }
+    #[inline]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 3usize, 3u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                3u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        a: ::std::os::raw::c_uint,
+        b: ::std::os::raw::c_uint,
+        c: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                1u8,
+                {
+                    let a: u32 = unsafe { ::std::mem::transmute(a) };
+                    a as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                1usize,
+                2u8,
+                {
+                    let b: u32 = unsafe { ::std::mem::transmute(b) };
+                    b as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                3usize,
+                3u8,
+                {
+                    let c: u32 = unsafe { ::std::mem::transmute(c) };
+                    c as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}
+/// <div rustbindgen derive="Clone, Copy"></div>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct second_bitfield_struct {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of second_bitfield_struct",
+    ][::std::mem::size_of::<second_bitfield_struct>() - 4usize];
+    [
+        "Alignment of second_bitfield_struct",
+    ][::std::mem::align_of::<second_bitfield_struct>() - 4usize];
+};
+impl second_bitfield_struct {
+    #[inline]
+    pub fn x(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u32) }
+    }
+    #[inline]
+    pub fn set_x(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn x_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 4u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_x_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                4u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn y(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u32) }
+    }
+    #[inline]
+    pub fn set_y(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn y_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 4usize, 4u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_y_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                4usize,
+                4u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        x: ::std::os::raw::c_uint,
+        y: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                4u8,
+                {
+                    let x: u32 = unsafe { ::std::mem::transmute(x) };
+                    x as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                4usize,
+                4u8,
+                {
+                    let y: u32 = unsafe { ::std::mem::transmute(y) };
+                    y as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
@@ -8,7 +8,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct _bindgen_ty_1 {
     pub _bindgen_align: [u64; 0],
     pub _bindgen_opaque_blob: __BindgenOpaqueArray8<[u8; 80usize]>,

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct mach_msg_type_descriptor_t {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -238,7 +244,7 @@ impl mach_msg_type_descriptor_t {
         pad3: ::std::os::raw::c_uint,
         type_: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct A {
     pub name: [::std::os::raw::c_uchar; 7usize],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
@@ -360,7 +366,7 @@ impl A {
         pestsBonus: ::std::os::raw::c_ushort,
         size: ::std::os::raw::c_ushort,
     ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -483,7 +489,7 @@ impl A {
         minYield: ::std::os::raw::c_uchar,
         waterBonus: ::std::os::raw::c_uchar,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Struct {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
@@ -341,7 +347,7 @@ impl Struct {
         d: ::std::os::raw::c_ushort,
         e: ::std::os::raw::c_uchar,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -391,7 +397,7 @@ impl Struct {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Inner {
     pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -479,7 +485,7 @@ impl Inner {
         a: ::std::os::raw::c_ushort,
         b: ::std::os::raw::c_ushort,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -502,7 +508,7 @@ impl Inner {
     }
 }
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Outer {
     pub inner: Inner,
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield_union_derives.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_union_derives.rs
@@ -1,0 +1,503 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+#[allow(unused_qualifications)]
+impl<Storage> __BindgenBitfieldUnit<Storage> {
+    #[inline]
+    pub const fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+#[allow(unused_qualifications)]
+impl<Storage> __BindgenBitfieldUnit<Storage>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
+    #[inline]
+    fn extract_bit(byte: u8, index: usize) -> bool {
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        byte & mask == mask
+    }
+    #[inline]
+    pub fn get_bit(&self, index: usize) -> bool {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = self.storage.as_ref()[byte_index];
+        Self::extract_bit(byte, index)
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
+        debug_assert!(index / 8 < core::mem::size_of::<Storage>());
+        let byte_index = index / 8;
+        let byte = unsafe {
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
+        };
+        Self::extract_bit(byte, index)
+    }
+    #[inline]
+    fn change_bit(byte: u8, index: usize, val: bool) -> u8 {
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        if val { byte | mask } else { byte & !mask }
+    }
+    #[inline]
+    pub fn set_bit(&mut self, index: usize, val: bool) {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = &mut self.storage.as_mut()[byte_index];
+        *byte = Self::change_bit(*byte, index, val);
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
+        debug_assert!(index / 8 < core::mem::size_of::<Storage>());
+        let byte_index = index / 8;
+        let byte = unsafe {
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
+        };
+        unsafe { *byte = Self::change_bit(*byte, index, val) };
+    }
+    #[inline]
+    pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if self.get_bit(i + bit_offset) {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= core::mem::size_of::<Storage>(),
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if unsafe { Self::raw_get_bit(this, i + bit_offset) } {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            self.set_bit(index + bit_offset, val_bit_is_set);
+        }
+    }
+    #[inline]
+    #[allow(dead_code)]
+    pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= core::mem::size_of::<Storage>(),
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
+        }
+    }
+}
+/// <div rustbindgen derive="PartialEq"></div>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct first_bitfield_struct {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of first_bitfield_struct",
+    ][::std::mem::size_of::<first_bitfield_struct>() - 4usize];
+    [
+        "Alignment of first_bitfield_struct",
+    ][::std::mem::align_of::<first_bitfield_struct>() - 4usize];
+};
+impl first_bitfield_struct {
+    #[inline]
+    pub fn a(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 1u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn b(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 2u8) as u32) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 1usize, 2u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                1usize,
+                2u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn c(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 3u8) as u32) }
+    }
+    #[inline]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 3usize, 3u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                3usize,
+                3u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        a: ::std::os::raw::c_uint,
+        b: ::std::os::raw::c_uint,
+        c: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                1u8,
+                {
+                    let a: u32 = unsafe { ::std::mem::transmute(a) };
+                    a as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                1usize,
+                2u8,
+                {
+                    let b: u32 = unsafe { ::std::mem::transmute(b) };
+                    b as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                3usize,
+                3u8,
+                {
+                    let c: u32 = unsafe { ::std::mem::transmute(c) };
+                    c as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}
+/// <div rustbindgen derive="PartialEq, Eq"></div>
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct second_bitfield_struct {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of second_bitfield_struct",
+    ][::std::mem::size_of::<second_bitfield_struct>() - 4usize];
+    [
+        "Alignment of second_bitfield_struct",
+    ][::std::mem::align_of::<second_bitfield_struct>() - 4usize];
+};
+impl second_bitfield_struct {
+    #[inline]
+    pub fn x(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u32) }
+    }
+    #[inline]
+    pub fn set_x(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn x_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 4u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_x_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                4u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn y(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u32) }
+    }
+    #[inline]
+    pub fn set_y(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn y_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 4usize, 4u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_y_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                4usize,
+                4u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        x: ::std::os::raw::c_uint,
+        y: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                4u8,
+                {
+                    let x: u32 = unsafe { ::std::mem::transmute(x) };
+                    x as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                4usize,
+                4u8,
+                {
+                    let y: u32 = unsafe { ::std::mem::transmute(y) };
+                    y as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct third_bitfield_struct {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of third_bitfield_struct",
+    ][::std::mem::size_of::<third_bitfield_struct>() - 4usize];
+    [
+        "Alignment of third_bitfield_struct",
+    ][::std::mem::align_of::<third_bitfield_struct>() - 4usize];
+};
+impl third_bitfield_struct {
+    #[inline]
+    pub fn z(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u32) }
+    }
+    #[inline]
+    pub fn set_z(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn z_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 8u8)
+                    as u32,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_z_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                8u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        z: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                8u8,
+                {
+                    let z: u32 = unsafe { ::std::mem::transmute(z) };
+                    z as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/blocklist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-file.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SizedIntegers {
     pub x: u8,
     pub y: u16,
@@ -21,7 +21,7 @@ const _: () = {
     ][::std::mem::offset_of!(SizedIntegers, z) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct StructWithBlocklistedFwdDecl {
     pub b: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/blocklist-function.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-function.rs
@@ -16,7 +16,7 @@ pub mod root {
         }
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct C {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
@@ -3,7 +3,7 @@
 mod bitfields;
 use bitfields::*;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub x: ::std::os::raw::c_uchar,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -94,7 +94,7 @@ impl C {
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/blocks-signature.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks-signature.rs
@@ -23,7 +23,7 @@ unsafe extern "C" {
     pub fn foo_ptr(arg1: *mut _bindgen_ty_id_56) -> bool;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct contains_block_pointers {
     pub val: contains_block_pointers__bindgen_ty_id_61,
     pub ptr_val: *mut _bindgen_ty_id_68,

--- a/bindgen-tests/tests/expectations/tests/blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks.rs
@@ -22,7 +22,7 @@ unsafe extern "C" {
     pub fn foo_ptr(arg1: *mut *mut ::std::os::raw::c_void) -> bool;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct contains_block_pointers {
     pub val: *mut ::std::os::raw::c_void,
     pub ptr_val: *mut *mut ::std::os::raw::c_void,

--- a/bindgen-tests/tests/expectations/tests/bug-1529681.rs
+++ b/bindgen-tests/tests/expectations/tests/bug-1529681.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct BrowsingContext {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {}
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/c_naming.rs
+++ b/bindgen-tests/tests/expectations/tests/c_naming.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct struct_a {
     pub a: ::std::os::raw::c_int,
 }
@@ -12,7 +12,7 @@ const _: () = {
 };
 pub type a = *const struct_a;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union union_b {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/call-conv-field.rs
+++ b/bindgen-tests/tests/expectations/tests/call-conv-field.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(not(test))]
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct JNINativeInterface_ {
     pub GetVersion: ::std::option::Option<
         unsafe extern "stdcall" fn(

--- a/bindgen-tests/tests/expectations/tests/canonical-types.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical-types.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ClassA {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassA_ClassAInner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: *mut T,
@@ -20,17 +20,17 @@ impl<T> Default for ClassA_ClassAInner<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ClassB {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ClassC {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassC_ClassCInnerB {
     pub cache: *mut ClassC_ClassCInnerA,
 }
@@ -44,7 +44,7 @@ impl Default for ClassC_ClassCInnerB {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassC_ClassCInnerA {
     pub member: *mut ClassC_ClassCInnerB,
 }
@@ -58,7 +58,7 @@ impl Default for ClassC_ClassCInnerA {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassC_ClassCInnerCRTP {
     pub _address: u8,
 }
@@ -72,7 +72,7 @@ impl Default for ClassC_ClassCInnerCRTP {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassD {
     pub _address: u8,
 }
@@ -100,7 +100,7 @@ const _: () = {
     ][::std::mem::align_of::<ClassB>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassCInnerCRTP {
     pub _address: u8,
 }
@@ -128,7 +128,7 @@ const _: () = {
     ][::std::mem::align_of::<ClassB>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassAInner {
     pub x: *mut ClassCInnerA,
 }
@@ -148,7 +148,7 @@ impl Default for ClassAInner {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassCInnerA {
     pub member: *mut ClassCInnerB,
 }
@@ -170,7 +170,7 @@ impl Default for ClassCInnerA {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ClassCInnerB {
     pub cache: *mut ClassCInnerA,
 }

--- a/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/char.rs
+++ b/bindgen-tests/tests/expectations/tests/char.rs
@@ -3,7 +3,7 @@ pub type Char = ::std::os::raw::c_char;
 pub type SChar = ::std::os::raw::c_schar;
 pub type UChar = ::std::os::raw::c_uchar;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Test {
     pub ch: ::std::os::raw::c_char,
     pub u: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/class.rs
+++ b/bindgen-tests/tests/expectations/tests/class.rs
@@ -30,7 +30,7 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct C {
     pub a: ::std::os::raw::c_int,
     pub big_array: [::std::os::raw::c_char; 33usize],
@@ -236,7 +236,7 @@ const _: () = {
     ) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct WithDtor {
     pub b: ::std::os::raw::c_int,
 }
@@ -277,7 +277,7 @@ impl Default for IncompleteArrayNonCopiable {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Union {
     pub d: f32,
     pub i: ::std::os::raw::c_int,
@@ -299,7 +299,7 @@ impl Default for Union {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct WithUnion {
     pub data: Union,
 }
@@ -321,7 +321,7 @@ impl Default for WithUnion {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RealAbstractionWithTonsOfMethods {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct A {
     pub member_a: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct A_B {
     pub member_b: ::std::os::raw::c_int,
 }
@@ -16,7 +16,7 @@ const _: () = {
     ["Offset of field: A_B::member_b"][::std::mem::offset_of!(A_B, member_b) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct A_D<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: T,
@@ -37,7 +37,7 @@ const _: () = {
     ["Offset of field: A::member_a"][::std::mem::offset_of!(A, member_a) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct A_C {
     pub baz: ::std::os::raw::c_int,
 }
@@ -63,7 +63,7 @@ unsafe extern "C" {
     pub static mut baz: A_D<::std::os::raw::c_int>;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct D {
     pub member: A_B,
 }
@@ -74,13 +74,13 @@ const _: () = {
     ["Offset of field: D::member"][::std::mem::offset_of!(D, member) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Templated<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member: T,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Templated_Templated_inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member_ptr: *mut T,

--- a/bindgen-tests/tests/expectations/tests/class_no_members.rs
+++ b/bindgen-tests/tests/expectations/tests/class_no_members.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct whatever {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of whatever"][::std::mem::align_of::<whatever>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct whatever_child {
     pub _address: u8,
 }
@@ -20,7 +20,7 @@ const _: () = {
     ["Alignment of whatever_child"][::std::mem::align_of::<whatever_child>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct whatever_child_with_member {
     pub m_member: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/class_static.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct MyClass {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/class_static_const.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static_const.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct A {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/class_use_as.rs
+++ b/bindgen-tests/tests/expectations/tests/class_use_as.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen="true" replaces="whatever"></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct whatever {
     pub replacement: ::std::os::raw::c_int,
 }
@@ -14,7 +14,7 @@ const _: () = {
     ][::std::mem::offset_of!(whatever, replacement) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct container {
     pub c: whatever,
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct HandleWithDtor<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: *mut T,
@@ -16,7 +16,7 @@ impl<T> Default for HandleWithDtor<T> {
 }
 pub type HandleValue = HandleWithDtor<::std::os::raw::c_int>;
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct WithoutDtor {
     pub shouldBeWithDtor: HandleValue,
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_enum.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct A {
     pub c: ::std::os::raw::c_uint,
     pub named_union: A__bindgen_ty_1,
     pub __bindgen_anon_1: A__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct A_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -22,7 +22,7 @@ const _: () = {
     ["Offset of field: A_Segment::end"][::std::mem::offset_of!(A_Segment, end) - 4usize];
 };
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union A__bindgen_ty_1 {
     pub f: ::std::os::raw::c_int,
 }
@@ -44,7 +44,7 @@ impl Default for A__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union A__bindgen_ty_2 {
     pub d: ::std::os::raw::c_int,
 }
@@ -82,12 +82,12 @@ impl Default for A {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct B {
     pub d: ::std::os::raw::c_uint,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct B_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
@@ -116,19 +116,19 @@ pub enum StepSyntax {
     FunctionalWithEndKeyword = 3,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct C {
     pub d: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: C__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union C__bindgen_ty_1 {
     pub mFunc: C__bindgen_ty_1__bindgen_ty_1,
     pub __bindgen_anon_1: C__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct C__bindgen_ty_1__bindgen_ty_1 {
     pub mX1: f32,
     pub mY1: f32,
@@ -157,7 +157,7 @@ const _: () = {
     ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_1, mY2) - 12usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct C__bindgen_ty_1__bindgen_ty_2 {
     pub mStepSyntax: StepSyntax,
     pub mSteps: ::std::os::raw::c_uint,
@@ -204,7 +204,7 @@ impl Default for C__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct C_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type AnotherInt = ::std::os::raw::c_int;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct C {
     pub c: C_MyInt,
     pub ptr: *mut C_MyInt,
@@ -65,7 +65,7 @@ impl C {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct D {
     pub _base: C,
     pub ptr: *mut C_MyInt,

--- a/bindgen-tests/tests/expectations/tests/comment-indent.rs
+++ b/bindgen-tests/tests/expectations/tests/comment-indent.rs
@@ -7,7 +7,7 @@ pub mod root {
 
  This class is really really interesting, look!*/
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Foo {
         pub _address: u8,
     }
@@ -15,7 +15,7 @@ pub mod root {
 
  This class is not so interesting, but worth a bit of docs too!*/
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Foo_Bar {
         pub _address: u8,
     }
@@ -35,7 +35,7 @@ pub mod root {
         /** I'm in a namespace, and thus I may be on a rust module, most of the time.
  My documentation is pretty extensive, I guess.*/
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Baz {
             /** This member is plain awesome, just amazing.
 
@@ -58,7 +58,7 @@ pub mod root {
  a rust module, except when the relevant option is specified. Also, this
  comment shouldn't be misaligned.*/
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct InInlineNS {
             pub _address: u8,
         }
@@ -68,7 +68,7 @@ pub mod root {
             ["Alignment of InInlineNS"][::std::mem::align_of::<InInlineNS>() - 1usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Bazz {
             pub _address: u8,
         }

--- a/bindgen-tests/tests/expectations/tests/complex.rs
+++ b/bindgen-tests/tests/expectations/tests/complex.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(C)]
 pub struct __BindgenComplex<T> {
     pub re: T,
     pub im: T,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct TestDouble {
     pub mMember: __BindgenComplex<f64>,
 }
@@ -19,7 +19,7 @@ const _: () = {
     ][::std::mem::offset_of!(TestDouble, mMember) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TestDoublePtr {
     pub mMember: *mut __BindgenComplex<f64>,
 }
@@ -41,7 +41,7 @@ impl Default for TestDoublePtr {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct TestFloat {
     pub mMember: __BindgenComplex<f32>,
 }
@@ -54,7 +54,7 @@ const _: () = {
     ][::std::mem::offset_of!(TestFloat, mMember) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct TestFloatPtr {
     pub mMember: *mut __BindgenComplex<f32>,
 }

--- a/bindgen-tests/tests/expectations/tests/complex_global.rs
+++ b/bindgen-tests/tests/expectations/tests/complex_global.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
 #[repr(C)]
 pub struct __BindgenComplex<T> {
     pub re: T,

--- a/bindgen-tests/tests/expectations/tests/complex_union_derives.rs
+++ b/bindgen-tests/tests/expectations/tests/complex_union_derives.rs
@@ -1,0 +1,58 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct __BindgenComplex<T> {
+    pub re: T,
+    pub im: T,
+}
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct first_complex_struct {
+    pub a: __BindgenComplex<f64>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of first_complex_struct",
+    ][::std::mem::size_of::<first_complex_struct>() - 16usize];
+    [
+        "Alignment of first_complex_struct",
+    ][::std::mem::align_of::<first_complex_struct>() - 8usize];
+    [
+        "Offset of field: first_complex_struct::a",
+    ][::std::mem::offset_of!(first_complex_struct, a) - 0usize];
+};
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct second_complex_struct {
+    pub b: __BindgenComplex<f32>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of second_complex_struct",
+    ][::std::mem::size_of::<second_complex_struct>() - 8usize];
+    [
+        "Alignment of second_complex_struct",
+    ][::std::mem::align_of::<second_complex_struct>() - 4usize];
+    [
+        "Offset of field: second_complex_struct::b",
+    ][::std::mem::offset_of!(second_complex_struct, b) - 0usize];
+};
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct third_complex_struct {
+    pub c: __BindgenComplex<f64>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of third_complex_struct",
+    ][::std::mem::size_of::<third_complex_struct>() - 16usize];
+    [
+        "Alignment of third_complex_struct",
+    ][::std::mem::align_of::<third_complex_struct>() - 8usize];
+    [
+        "Offset of field: third_complex_struct::c",
+    ][::std::mem::offset_of!(third_complex_struct, c) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub bar: *const *const *mut *const ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct strct {
     pub field: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/const_bool.rs
+++ b/bindgen-tests/tests/expectations/tests/const_bool.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const k: bool = true;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
+++ b/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
@@ -8,7 +8,7 @@ pub enum _bindgen_ty_1 {
     FOO_BAZ = 1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/const_tparam.rs
+++ b/bindgen-tests/tests/expectations/tests/const_tparam.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: *const T,

--- a/bindgen-tests/tests/expectations/tests/constant-non-specialized-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constant-non-specialized-tp.rs
@@ -1,16 +1,16 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Outer {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Outer_Inner {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -1,17 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub _address: u8,
 }
 pub type C_U = B;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub u: B,
 }

--- a/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
@@ -4,7 +4,7 @@ pub const foo_SHOULD_BE: foo = 1;
 pub const foo_A_CONSTANT: foo = 2;
 pub type foo = ::std::os::raw::c_uint;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct bar {
     pub this_should_work: foo,
 }

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
@@ -10,7 +10,7 @@ pub mod foo {
 pub use self::foo::Type as foo_alias1;
 pub use self::foo_alias1 as foo_alias2;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct bar {
     pub this_should_work: foo::Type,
 }

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -22,7 +22,7 @@ pub mod root {
             #[allow(unused_imports)]
             use self::super::super::super::root;
             #[repr(C)]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Clone, Copy, Debug)]
             pub struct bar {
                 pub this_should_work: root::ns1::ns2::foo::Type,
             }

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -9,7 +9,7 @@ pub mod foo {
     pub const Type__: Type = 3;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct bar {
     pub member: foo::Type,
 }

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -11,7 +11,7 @@ pub use self::Foo::Type as Foo_alias1;
 pub use self::Foo_alias1 as Foo_alias2;
 pub use self::Foo_alias2 as Foo_alias3;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bar {
     pub baz1: Foo::Type,
     pub baz2: Foo_alias1,

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -7,7 +7,7 @@ pub mod one_Foo {
     pub const Variant2: Type = 1;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bar {
     pub baz1: one_Foo::Type,
     pub baz2: *mut one_Foo::Type,

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -48,7 +48,7 @@ pub use self::anon_enum::Type as anon_enum_alias1;
 pub use self::anon_enum_alias1 as anon_enum_alias2;
 pub use self::anon_enum_alias2 as anon_enum_alias3;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct bar {
     pub member1: foo::Type,
     pub member2: foo_alias1,
@@ -86,7 +86,7 @@ impl Default for bar {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Baz {
     pub member1: ns2_Foo::Type,
 }
@@ -113,7 +113,7 @@ pub mod one_Foo {
     pub const Variant2: Type = 1;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bar {
     pub baz: *mut one_Foo::Type,
 }
@@ -149,7 +149,7 @@ unsafe extern "C" {
     ) -> *mut foo_alias1;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Thing<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub thing: T,

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TestOverload {
     pub _address: u8,
 }
@@ -35,7 +35,7 @@ impl TestOverload {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TestPublicNoArgs {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TestOverload {
     pub _address: u8,
 }
@@ -37,7 +37,7 @@ impl TestOverload {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TestPublicNoArgs {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// This should get an `_address` byte.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Empty {
     pub _address: u8,
 }
@@ -13,7 +13,7 @@ const _: () = {
 /** This should not get an `_address` byte, so `sizeof(Inherits)` should be
  `1`.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Inherits {
     pub b: bool,
 }
@@ -26,7 +26,7 @@ const _: () = {
 /** This should not get an `_address` byte, but contains `Empty` which *does* get
  one, so `sizeof(Contains)` should be `1 + 1`.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Contains {
     pub empty: Empty,
     pub b: bool,

--- a/bindgen-tests/tests/expectations/tests/convert-cpp-comment-to-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/convert-cpp-comment-to-rust.rs
@@ -2,7 +2,7 @@
 pub type mbedtls_mpi_uint = ::std::os::raw::c_uint;
 /// \brief          MPI structure
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct mbedtls_mpi {
     ///<  integer sign
     pub s: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/convert-floats.rs
+++ b/bindgen-tests/tests/expectations/tests/convert-floats.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct __BindgenComplex<T> {
     pub re: T,
     pub im: T,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub bar: ::std::os::raw::c_float,
     pub baz: ::std::os::raw::c_float,

--- a/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/crtp.rs
+++ b/bindgen-tests/tests/expectations/tests/crtp.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Base {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Derived {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
@@ -7,7 +7,7 @@ mod libc {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub a: libc::foo::c_int,
     pub b: libc::foo::c_int,

--- a/bindgen-tests/tests/expectations/tests/dash_language.rs
+++ b/bindgen-tests/tests/expectations/tests/dash_language.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Foo<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,18 +145,20 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     pub(crate) x: ::std::os::raw::c_int,
     pub(crate) y: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Color {
     pub(crate) _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -268,7 +274,7 @@ impl Color {
         g: ::std::os::raw::c_char,
         b: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,18 +145,20 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     x: ::std::os::raw::c_int,
     y: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Color {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -268,7 +274,7 @@ impl Color {
         g: ::std::os::raw::c_char,
         b: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,18 +145,20 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Color {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -268,7 +274,7 @@ impl Color {
         g: ::std::os::raw::c_char,
         b: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/deleted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/deleted-function.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _address: u8,
 }
@@ -28,7 +28,7 @@ impl A {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub _address: u8,
 }
@@ -38,7 +38,7 @@ const _: () = {
     ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -149,7 +155,7 @@ where
  and --with-derive-partialeq --impl-partialeq --impl-debug is provided,
  this struct should manually implement `Debug` and `PartialEq`.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Foo {
     pub large: [::std::os::raw::c_int; 33usize],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
@@ -227,7 +233,7 @@ impl Foo {
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/derive-clone.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-clone.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// This struct should derive `Clone`.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ShouldDeriveClone {
     pub large: [::std::os::raw::c_int; 33usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-custom.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-custom.rs
@@ -1,20 +1,20 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen derive="Debug"></div>
 #[repr(C)]
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct my_type {
     pub a: ::std::os::raw::c_int,
 }
 /** <div rustbindgen derive="Debug"></div>
  <div rustbindgen derive="Clone"></div>*/
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct my_type2 {
     pub a: ::std::os::raw::c_uint,
 }
 /// <div rustbindgen derive="Debug" derive="Clone"></div>
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct my_type3 {
     pub a: ::std::os::raw::c_ulong,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
@@ -239,7 +245,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -1,16 +1,18 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 extern crate core;
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -33,12 +35,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -60,12 +62,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -90,6 +92,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -128,6 +131,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -142,12 +146,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::core::ffi::c_int; 50usize],
@@ -244,7 +250,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
@@ -239,7 +245,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Nice {
     pub pointer: Nice_Function,
     pub large_array: [::std::os::raw::c_int; 34usize],

--- a/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct perf_event_attr {
     pub type_: ::std::os::raw::c_uint,
     pub a: f32,
     pub __bindgen_anon_1: perf_event_attr__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union perf_event_attr__bindgen_ty_1 {
     pub b: ::std::os::raw::c_int,
     pub c: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,7 +8,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Instance {
     pub val: __BindgenOpaqueArray<[u32; 50usize]>,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -9,7 +9,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Opaque {
     pub _bindgen_opaque_blob: __BindgenOpaqueArray<[u32; 41usize]>,
 }
@@ -19,7 +19,7 @@ const _: () = {
     ["Alignment of Opaque"][::std::mem::align_of::<Opaque>() - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct OpaqueUser {
     pub opaque: Opaque,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
@@ -20,7 +20,7 @@ pub type my_fun_t = ::std::option::Option<
     ),
 >;
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct Foo {
     pub callback: my_fun_t,
 }
@@ -47,7 +47,7 @@ pub type my_fun2_t = ::std::option::Option<
     ),
 >;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Bar {
     pub callback: my_fun2_t,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// A struct containing a struct containing a float that cannot derive Hash/Eq/Ord but can derive PartialEq/PartialOrd
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
 pub struct foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
 pub struct foo__bindgen_ty_1 {
     pub a: f32,
     pub b: f32,

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// A struct containing an array of floats that cannot derive Hash/Eq/Ord but can derive PartialEq/PartialOrd
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
 pub struct foo {
     pub bar: [f32; 3usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// Pointers can derive Hash/PartialOrd/Ord/PartialEq/Eq
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ConstPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
@@ -23,7 +23,7 @@ impl Default for ConstPtrMutObj {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MutPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
@@ -45,7 +45,7 @@ impl Default for MutPtrMutObj {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MutPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }
@@ -67,7 +67,7 @@ impl Default for MutPtrConstObj {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ConstPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-def-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-def-float.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// Template definition containing a float, which cannot derive Hash/Eq/Ord but can derive PartialEq/PartialOrd.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct foo<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub data: T,

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// Template definition that doesn't contain float can derive Hash/PartialOrd/Ord/PartialEq/Eq
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct foo<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub data: T,
@@ -17,7 +17,7 @@ impl<T> Default for foo<T> {
 }
 /// Can derive Hash/PartialOrd/Ord/PartialEq/Eq when instantiated with int
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct IntStr {
     pub a: foo<::std::os::raw::c_int>,
 }
@@ -38,7 +38,7 @@ impl Default for IntStr {
 }
 /// Cannot derive Hash/Eq/Ord when instantiated with float but can derive PartialEq/PartialOrd
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 pub struct FloatStr {
     pub a: foo<f32>,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_mbuf {
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_1,
 }
 #[repr(C)]
 #[repr(align(1))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_mbuf__bindgen_ty_1 {
     pub bindgen_union_field: [u8; 0usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Base {
     pub large: [::std::os::raw::c_int; 33usize],
 }
@@ -20,7 +20,7 @@ impl Default for Base {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ShouldDerivePartialEq {
     pub _base: Base,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
@@ -239,7 +245,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 extern crate core;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct C {
     pub large_array: [::core::ffi::c_int; 420usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Bar {
     pub b: *mut a,
 }
@@ -20,12 +20,12 @@ impl Default for Bar {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct c {
     pub __bindgen_anon_1: c__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union c__bindgen_ty_1 {
     pub _address: u8,
 }
@@ -58,7 +58,7 @@ impl Default for c {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct a {
     pub d: c,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// Deriving PartialEq for rust unions is not supported.
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union ShouldNotDerivePartialEq {
     pub a: ::std::os::raw::c_char,
     pub b: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -1,29 +1,29 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub b1: bar1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar1 {
     pub x1: ::std::os::raw::c_int,
     pub b2: bar1__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar1__bindgen_ty_1 {
     pub x2: ::std::os::raw::c_int,
     pub b3: bar1__bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar1__bindgen_ty_1__bindgen_ty_1 {
     pub x3: ::std::os::raw::c_int,
     pub b4: bar4,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar4 {
     pub x4: ::std::os::raw::c_int,
 }
@@ -77,17 +77,17 @@ const _: () = {
     ["Offset of field: foo::b1"][::std::mem::offset_of!(foo, b1) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct _bindgen_ty_1 {
     pub anon2: _bindgen_ty_1__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct _bindgen_ty_1__bindgen_ty_1 {
     pub b: baz,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct baz {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -43,7 +43,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub bar: __BindgenUnionField<::std::os::raw::c_int>,
     pub baz: __BindgenUnionField<::std::os::raw::c_uint>,

--- a/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithBitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
@@ -154,12 +160,12 @@ pub struct WithBitfield {
 impl WithBitfield {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
     }
 }
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithBitfieldAndAttrPacked {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
@@ -167,12 +173,12 @@ pub struct WithBitfieldAndAttrPacked {
 impl WithBitfieldAndAttrPacked {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
     }
 }
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithBitfieldAndPacked {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
@@ -180,7 +186,7 @@ pub struct WithBitfieldAndPacked {
 impl WithBitfieldAndPacked {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
     }
 }

--- a/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
+++ b/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq)]
 pub struct Doggo {
     pub x: ::std::os::raw::c_int,
 }
@@ -11,7 +11,7 @@ const _: () = {
     ["Offset of field: Doggo::x"][::std::mem::offset_of!(Doggo, x) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq)]
 pub struct Null {
     pub _address: u8,
 }
@@ -28,7 +28,7 @@ const _: () = {
  this test to make sure that opaque unions don't derive and still compile.*/
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union DoggoOrNull {
     pub _bindgen_opaque_blob: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct BitStream {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Bar {
             pub foo: ::std::os::raw::c_int,
             pub baz: bool,
@@ -24,7 +24,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Copy, Clone)]
+        #[derive(Clone, Copy, Debug)]
         pub struct Foo {
             pub ptr: *mut root::foo::Bar,
         }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct X {
     pub _x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/empty-union.rs
+++ b/bindgen-tests/tests/expectations/tests/empty-union.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union a__bindgen_ty_1 {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/empty_template_param_name.rs
+++ b/bindgen-tests/tests/expectations/tests/empty_template_param_name.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type __void_t = ::std::os::raw::c_void;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct __iterator_traits {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub member: foo__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub member: foo__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/enum-default-module.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-module.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub member: foo__bindgen_ty_1::Type,
 }

--- a/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub member: foo__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo {
     pub member: foo__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/enum.rs
+++ b/bindgen-tests/tests/expectations/tests/enum.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub member: foo__bindgen_ty_1,
 }

--- a/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -12,7 +12,7 @@ pub struct C__bindgen_vtable {
     pub C_match: unsafe extern "C" fn(this: *mut C),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub vtable_: *const C__bindgen_vtable,
     pub i: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/enum_in_template.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_in_template.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/enum_in_template_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_in_template_with_typedef.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct std_fbstring_core {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/eval-value-dependent.rs
+++ b/bindgen-tests/tests/expectations/tests/eval-value-dependent.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct e {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/eval-variadic-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/eval-variadic-template-parameter.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/explicit-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/explicit-padding.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct pad_me {
     pub first: u8,
     pub __bindgen_padding_0: [u8; 3usize],
@@ -17,7 +17,7 @@ const _: () = {
     ["Offset of field: pad_me::third"][::std::mem::offset_of!(pad_me, third) - 8usize];
 };
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union dont_pad_me {
     pub first: u8,
     pub second: u32,

--- a/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsFoo {
     pub details: [f32; 400usize],
 }

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct my_struct {
     pub a: ::std::os::raw::c_int,
     private_b: ::std::os::raw::c_int,
@@ -240,7 +246,7 @@ impl my_struct {
         c: ::std::os::raw::c_int,
         private_d: ::std::os::raw::c_int,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct my_struct1 {
     pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -196,7 +202,7 @@ impl my_struct1 {
     }
     #[inline]
     fn new_bitfield_1(a: ::std::os::raw::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -210,7 +216,7 @@ impl my_struct1 {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct my_struct2 {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -262,7 +268,7 @@ impl my_struct2 {
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_int,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/field_attr_annotation.rs
+++ b/bindgen-tests/tests/expectations/tests/field_attr_annotation.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen deriveDebug></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     /// <div rustbindgen attribute="cfg(test)"></div>
     #[cfg(test)]
@@ -19,7 +19,7 @@ const _: () = {
 };
 /// <div rustbindgen deriveDebug></div>
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Data {
     /// <div rustbindgen attribute="allow(dead_code)"></div>
     #[allow(dead_code)]

--- a/bindgen-tests/tests/expectations/tests/field_attr_cli.rs
+++ b/bindgen-tests/tests/expectations/tests/field_attr_cli.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     #[cfg(test)]
     pub x: ::std::os::raw::c_int,
@@ -15,7 +15,7 @@ const _: () = {
     ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
 };
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Data {
     #[allow(dead_code)]
     pub i: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/flexarray.rs
+++ b/bindgen-tests/tests/expectations/tests/flexarray.rs
@@ -308,7 +308,7 @@ impl<T> Default for flexarray_template<T, [T; 0]> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct flexarray_ref {
     pub things: *mut flexarray,
 }

--- a/bindgen-tests/tests/expectations/tests/float16.rs
+++ b/bindgen-tests/tests/expectations/tests/float16.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Copy, Clone, Hash, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 #[repr(transparent)]
 pub struct __BindgenFloat16(pub u16);
 unsafe extern "C" {
     pub static mut global: __BindgenFloat16;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Test__Float16 {
     pub f: __BindgenFloat16,
 }
@@ -19,7 +19,7 @@ const _: () = {
     ][::std::mem::offset_of!(Test__Float16, f) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Test__Float16Ref {
     pub f: *mut __BindgenFloat16,
 }

--- a/bindgen-tests/tests/expectations/tests/float16_union_derives.rs
+++ b/bindgen-tests/tests/expectations/tests/float16_union_derives.rs
@@ -1,0 +1,55 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[repr(transparent)]
+pub struct __BindgenFloat16(pub u16);
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct first_float16_struct {
+    pub a: __BindgenFloat16,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of first_float16_struct",
+    ][::std::mem::size_of::<first_float16_struct>() - 2usize];
+    [
+        "Alignment of first_float16_struct",
+    ][::std::mem::align_of::<first_float16_struct>() - 2usize];
+    [
+        "Offset of field: first_float16_struct::a",
+    ][::std::mem::offset_of!(first_float16_struct, a) - 0usize];
+};
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct second_float16_struct {
+    pub b: __BindgenFloat16,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of second_float16_struct",
+    ][::std::mem::size_of::<second_float16_struct>() - 2usize];
+    [
+        "Alignment of second_float16_struct",
+    ][::std::mem::align_of::<second_float16_struct>() - 2usize];
+    [
+        "Offset of field: second_float16_struct::b",
+    ][::std::mem::offset_of!(second_float16_struct, b) - 0usize];
+};
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct third_float16_struct {
+    pub c: __BindgenFloat16,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of third_float16_struct",
+    ][::std::mem::size_of::<third_float16_struct>() - 2usize];
+    [
+        "Alignment of third_float16_struct",
+    ][::std::mem::align_of::<third_float16_struct>() - 2usize];
+    [
+        "Offset of field: third_float16_struct::c",
+    ][::std::mem::offset_of!(third_float16_struct, c) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -5,7 +5,7 @@ pub struct Foo {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct RefPtr<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m_inner: *mut T,

--- a/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct js_RootedBase<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: *mut T,
@@ -16,7 +16,7 @@ impl<T> Default for js_RootedBase<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _base: js_RootedBase<T>,

--- a/bindgen-tests/tests/expectations/tests/forward-inherit-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-inherit-struct.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct js_RootedBase {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo_empty {
     pub _address: u8,
 }
@@ -15,7 +15,7 @@ pub struct Foo {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bar {
     pub f: *mut Foo,
 }

--- a/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct a {
     pub b: ::std::os::raw::c_int,
 }
@@ -11,7 +11,7 @@ const _: () = {
     ["Offset of field: a::b"][::std::mem::offset_of!(a, b) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct c {
     pub d: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
@@ -5,7 +5,7 @@ pub enum baz {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Foo {
     pub bar: ::std::option::Option<
         unsafe extern "C" fn(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> baz,

--- a/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
+++ b/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
@@ -5,7 +5,7 @@ unsafe extern "C" {
     pub fn return_int() -> MustUseInt;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct MustUseStruct {
     pub a: ::std::os::raw::c_int,
@@ -33,7 +33,7 @@ unsafe extern "C" {
 }
 /// <div rustbindgen mustusetype></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 #[must_use]
 pub struct AnnotatedStruct {
     pub a: ::std::os::raw::c_int,
@@ -51,7 +51,7 @@ unsafe extern "C" {
     pub fn return_annotated_struct() -> AnnotatedStruct;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PlainStruct {
     pub a: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/i128.rs
+++ b/bindgen-tests/tests/expectations/tests/i128.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub my_signed: i128,
     pub my_unsigned: u128,

--- a/bindgen-tests/tests/expectations/tests/in_class_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/in_class_typedef.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
 pub type Foo_elem_type<T> = T;
 pub type Foo_ptr_type<T> = *mut T;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo_Bar {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -236,7 +242,7 @@ impl foo {
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -3,7 +3,7 @@
 pub struct BaseWithVtable__bindgen_vtable {}
 /// This should have an explicit vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct BaseWithVtable<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub vtable_: *const BaseWithVtable__bindgen_vtable,
@@ -20,7 +20,7 @@ impl<T> Default for BaseWithVtable<T> {
 }
 /// This should not have an explicit vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DerivedWithNoVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
@@ -44,7 +44,7 @@ impl Default for DerivedWithNoVirtualMethods {
 }
 /// This should not have an explicit vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DerivedWithVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
@@ -68,7 +68,7 @@ impl Default for DerivedWithVirtualMethods {
 }
 /// This should not have any vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct BaseWithoutVtable<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub u: U,
@@ -86,7 +86,7 @@ impl<U> Default for BaseWithoutVtable<U> {
 pub struct DerivedWithVtable__bindgen_vtable(::std::os::raw::c_void);
 /// This should have an explicit vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DerivedWithVtable {
     pub vtable_: *const DerivedWithVtable__bindgen_vtable,
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
@@ -109,7 +109,7 @@ impl Default for DerivedWithVtable {
 }
 /// This should not have any vtable.
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DerivedWithoutVtable {
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
 }

--- a/bindgen-tests/tests/expectations/tests/inherit-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-namespaced.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct js_RootedBase {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
@@ -2,7 +2,7 @@
 #[repr(C)]
 pub struct A__bindgen_vtable {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct A {
     pub vtable_: *const A__bindgen_vtable,
     pub member: ::std::os::raw::c_int,
@@ -25,7 +25,7 @@ impl Default for A {
 #[repr(C)]
 pub struct B__bindgen_vtable {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct B {
     pub vtable_: *const B__bindgen_vtable,
     pub member2: *mut ::std::os::raw::c_void,
@@ -46,7 +46,7 @@ impl Default for B {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub _base: A,
     pub _base_1: B,

--- a/bindgen-tests/tests/expectations/tests/inherit_named.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_named.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Wohoo {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Weeee<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _base: T,

--- a/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
@@ -11,7 +11,7 @@ const _: () = {
 };
 pub type TypedefedFoo = Foo;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace.rs
@@ -9,7 +9,7 @@ pub mod root {
         pub type Ty = ::std::os::raw::c_int;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Bar {
         pub baz: root::foo::Ty,
     }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
@@ -14,7 +14,7 @@ pub mod root {
         pub type Ty = ::std::os::raw::c_longlong;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Bar {
         pub baz: root::foo::bar::Ty,
     }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_macro.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_macro.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct duration {
             pub _address: u8,
         }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
@@ -8,7 +8,7 @@ pub struct std_basic_string<CharT> {
     pub __bindgen_anon_1: std_basic_string__bindgen_ty_1<CharT>,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct std_basic_string_Alloc_hider {
     pub storage: *mut ::std::os::raw::c_void,
 }

--- a/bindgen-tests/tests/expectations/tests/inner-typedef-gh422.rs
+++ b/bindgen-tests/tests/expectations/tests/inner-typedef-gh422.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Foo_InnerType<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
@@ -25,7 +25,7 @@ unsafe extern "C" {
     pub fn func() -> Bar;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct InnerType {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/inner_const.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_const.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/inner_template_self.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_template_self.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct LinkedList {
     pub next: *mut LinkedList,
     pub prev: *mut LinkedList,
@@ -15,7 +15,7 @@ impl Default for LinkedList {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct InstantiateIt {
     pub m_list: LinkedList,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1025-unknown-enum-repr.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1025-unknown-enum-repr.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct a {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct S2 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
@@ -158,7 +164,7 @@ const _: () = {
 impl S2 {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct S1 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
@@ -158,7 +164,7 @@ const _: () = {
 impl S1 {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Entry<K, V> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<K>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
@@ -17,13 +17,13 @@ impl<K, V> Default for Entry<K, V> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct nsBaseHashtable {
     pub _address: u8,
 }
 pub type nsBaseHashtable_EntryType<K, V> = Entry<K, V>;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsBaseHashtable_EntryPtr<K, V> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<K>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,

--- a/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type c = nsTArray;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsTArray_base {
     pub d: *mut ::std::os::raw::c_int,
 }
@@ -23,7 +23,7 @@ impl Default for nsTArray_base {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsTArray {
     pub _base: nsTArray_base,
 }
@@ -37,7 +37,7 @@ impl Default for nsTArray {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsIContent {
     pub foo: nsTArray,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn f(a: ::std::os::raw::c_int, ...);
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub f: ::std::option::Option<
         unsafe extern "C" fn(

--- a/bindgen-tests/tests/expectations/tests/issue-1281.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1281.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar {
     pub u: foo,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub foo: ::std::os::raw::c_int,
 }
@@ -23,7 +23,7 @@ const _: () = {
 };
 pub type bar_t = bar;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct baz {
     pub f: foo,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1285.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1285.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,

--- a/bindgen-tests/tests/expectations/tests/issue-1291.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1291.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RTCRay {
     pub org: [f32; 3usize],
     pub align0: f32,

--- a/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -8,7 +8,7 @@ pub type u32_ = u32;
 pub type i64_ = i64;
 pub type u64_ = u64;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub i8_: ::std::os::raw::c_int,
     pub u8_: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/issue-1443.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1443.rs
@@ -5,7 +5,7 @@ pub struct Foo {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
@@ -27,7 +27,7 @@ impl Default for Bar {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Baz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,
@@ -49,7 +49,7 @@ impl Default for Baz {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
@@ -71,7 +71,7 @@ impl Default for Tar {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Taz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,

--- a/bindgen-tests/tests/expectations/tests/issue-1498.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1498.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C, packed)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_memseg {
     ///< Start physical address.
     pub phys_addr: u64,
@@ -17,7 +17,7 @@ pub struct rte_memseg {
     pub nrank: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_memseg__bindgen_ty_1 {
     ///< Start virtual address.
     pub addr: *mut ::std::os::raw::c_void,

--- a/bindgen-tests/tests/expectations/tests/issue-1514.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1514.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Thing {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Thing_Inner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: *mut T,
@@ -20,7 +20,7 @@ impl<T> Default for Thing_Inner<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Thing_AnotherInner<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _base: Thing_Inner<T>,

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,14 +145,16 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 pub type U8 = ::std::os::raw::c_uchar;
 pub type U16 = ::std::os::raw::c_ushort;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct V56AMDY {
     pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
@@ -317,7 +323,7 @@ impl V56AMDY {
         MAI1: U16,
         MAI2: U16,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -581,7 +587,7 @@ impl V56AMDY {
         MABW: U8,
         MAXN: U8,
     ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct S {
     pub large_array: [::std::os::raw::c_char; 33usize],
 }
@@ -20,7 +20,7 @@ impl Default for S {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ST<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub large_array: [T; 33usize],

--- a/bindgen-tests/tests/expectations/tests/issue-1995.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1995.rs
@@ -7,7 +7,7 @@ pub const FOO: ::std::os::raw::c_int = 1;
 
  And expected to be found in generated bindings code too.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub baz: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub a: ::std::os::raw::c_int,
 }
@@ -21,7 +21,7 @@ impl A {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub b: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-2239-template-dependent-bit-width.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2239-template-dependent-bit-width.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct b {
     pub _address: u8,
 }
 pub type b_td<a> = a;
 pub type b_ta<a> = a;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct b_foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2556.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct nsSize {
         pub width: ::std::os::raw::c_int,
         pub height: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/issue-2695.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2695.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test {
     pub x: ::std::os::raw::c_ulong,
     pub a: ::std::os::raw::c_char,

--- a/bindgen-tests/tests/expectations/tests/issue-3027.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3027.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
-    #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+    #[derive(Clone, Copy, Debug)]
     #[repr(C)]
     pub struct __BindgenOpaqueArray<T>(pub T);
     impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -15,7 +15,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct C {
             pub a: root::__BindgenOpaqueArray<[u8; 3usize]>,
         }

--- a/bindgen-tests/tests/expectations/tests/issue-358.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-358.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct JS_PersistentRooted {
     pub _base: a,
 }
@@ -14,7 +14,7 @@ impl Default for JS_PersistentRooted {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct a {
     pub b: *mut a,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-372.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-372.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
-    #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+    #[derive(Clone, Copy, Debug)]
     #[repr(C, align(8))]
     pub struct __BindgenOpaqueArray8<T>(pub T);
     impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
@@ -12,7 +12,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Clone, Copy, Debug)]
     pub struct i {
         pub j: *mut root::i,
         pub k: *mut root::i,
@@ -36,7 +36,7 @@ pub mod root {
         }
     }
     #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Clone, Copy, Debug)]
     pub struct d {
         pub m: root::i,
     }
@@ -72,7 +72,7 @@ pub mod root {
         ai = 11,
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct F {
         pub w: root::__BindgenOpaqueArray8<[u8; 264usize]>,
     }

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Value {
             pub _address: u8,
         }

--- a/bindgen-tests/tests/expectations/tests/issue-446.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-446.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct List {
     pub next: *mut List,
 }
@@ -14,7 +14,7 @@ impl Default for List {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PersistentRooted {
     pub root_list: List,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -10,7 +10,7 @@ pub mod root {
             #[allow(unused_imports)]
             use self::super::super::super::root;
             #[repr(C)]
-            #[derive(Debug, Default, Copy, Clone)]
+            #[derive(Clone, Copy, Debug, Default)]
             pub struct GuardObjectNotifier {
                 pub _address: u8,
             }
@@ -26,7 +26,7 @@ pub mod root {
         }
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct JSAutoCompartment {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/issue-493.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493.rs
@@ -43,7 +43,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct basic_string {
     pub _address: u8,
 }
@@ -51,7 +51,7 @@ pub type basic_string_size_type = ::std::os::raw::c_ulonglong;
 pub type basic_string_value_type = ::std::os::raw::c_char;
 pub type basic_string_pointer = *mut basic_string_value_type;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct basic_string___long {
     pub __cap_: basic_string_size_type,
     pub __size_: basic_string_size_type,
@@ -123,7 +123,7 @@ pub enum basic_string__bindgen_ty_2 {
     __n_words = 0,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct basic_string___raw {
     pub __words: *mut basic_string_size_type,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -3,7 +3,7 @@
 /** This should not be opaque; we can see the attributes and can pack the
  struct.*/
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AlignedToOne {
     pub i: ::std::os::raw::c_int,
 }
@@ -17,7 +17,7 @@ const _: () = {
 };
 /// This should be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AlignedToTwo {
     pub i: ::std::os::raw::c_int,
 }
@@ -33,7 +33,7 @@ const _: () = {
  `#pragma pack(1)`, we can detect that alignment is 1 and add
  `#[repr(packed)]` to the struct ourselves.*/
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PackedToOne {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
@@ -47,7 +47,7 @@ const _: () = {
 };
 /// This should be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PackedToTwo {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/issue-537.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537.rs
@@ -2,7 +2,7 @@
 /** This should not be opaque; we can see the attributes and can pack the
  struct.*/
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AlignedToOne {
     pub i: ::std::os::raw::c_int,
 }
@@ -17,7 +17,7 @@ const _: () = {
 /** This should be opaque because although we can see the attributes, Rust before
  1.33 doesn't have `#[repr(packed(N))]`.*/
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AlignedToTwo {
     pub i: ::std::os::raw::c_int,
 }
@@ -33,7 +33,7 @@ const _: () = {
  `#pragma pack(1)`, we can detect that alignment is 1 and add
  `#[repr(packed)]` to the struct ourselves.*/
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PackedToOne {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
@@ -49,7 +49,7 @@ const _: () = {
  `#pragma pack(2)`, we can't do anything about it because Rust before 1.33
  doesn't have `#[repr(packed(N))]`. Therefore, we must make it opaque.*/
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PackedToTwo {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,7 +7,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Foo {
     pub member: *mut Foo_SecondAlias,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct a {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -9,7 +9,7 @@ pub enum _bindgen_ty_1 {
 }
 pub type JS_Alias = u8;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct JS_Base {
     pub f: JS_Alias,
 }
@@ -23,7 +23,7 @@ impl Default for JS_Base {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Outer {
     pub i: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct AutoIdVector {
     pub ar: Outer,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct a {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct _bindgen_ty_1 {
     pub ar: a,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type RefPtr<T> = T;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _address: u8,
 }
@@ -26,7 +26,7 @@ impl<c> Default for e<c> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct f {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct RefPtr<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub use_of_t: T,
@@ -15,7 +15,7 @@ impl<T> Default for RefPtr<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesRefPtrWithAliasedTypeParam<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub member: RefPtr<UsesRefPtrWithAliasedTypeParam_V<U>>,

--- a/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub bar: Foo_Bar,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo_Bar {
     pub abc: ::std::os::raw::c_int,
 }
@@ -22,12 +22,12 @@ const _: () = {
     ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Baz {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Baz_Bar {
     pub abc: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
@@ -38,7 +38,7 @@ pub struct rte_ring {
     pub ring: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct rte_ring_prod {
     pub watermark: ::std::os::raw::c_uint,
 }
@@ -51,7 +51,7 @@ const _: () = {
     ][::std::mem::offset_of!(rte_ring_prod, watermark) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct rte_ring_cons {
     pub sc_dequeue: ::std::os::raw::c_uint,
 }
@@ -88,7 +88,7 @@ impl Default for rte_ring {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct rte_memzone {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -3,7 +3,7 @@
  Debug/Hash because 63 is over the hard coded limit.*/
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct NoDebug {
     pub c: ::std::os::raw::c_char,
 }
@@ -28,7 +28,7 @@ impl Default for NoDebug {
  codegen.*/
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ShouldDeriveDebugButDoesNot {
     pub c: [::std::os::raw::c_char; 32usize],
     pub d: ::std::os::raw::c_char,

--- a/bindgen-tests/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct RefPtr<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub a: T,
@@ -15,7 +15,7 @@ impl<T> Default for RefPtr<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsMainThreadPtrHolder<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub a: T,
@@ -30,7 +30,7 @@ impl<T> Default for nsMainThreadPtrHolder<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsMainThreadPtrHandle<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub mPtr: RefPtr<nsMainThreadPtrHolder<T>>,

--- a/bindgen-tests/tests/expectations/tests/issue-662-part-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-662-part-2.rs
@@ -2,7 +2,7 @@
 #[derive(Clone, Copy, Debug)]
 pub struct RefPtr<T>(T);
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsMainThreadPtrHolder<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub a: T,

--- a/bindgen-tests/tests/expectations/tests/issue-674-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-1.rs
@@ -7,14 +7,14 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Maybe {
             pub _address: u8,
         }
         pub type Maybe_ValueType<T> = T;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct CapturingContentInfo {
         pub a: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/issue-674-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-2.rs
@@ -7,14 +7,14 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Rooted {
             pub _address: u8,
         }
         pub type Rooted_ElementType<T> = T;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct c {
         pub b: u8,
     }
@@ -25,7 +25,7 @@ pub mod root {
         ["Offset of field: c::b"][::std::mem::offset_of!(c, b) - 0usize];
     };
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct B {
         pub a: root::c,
     }
@@ -36,7 +36,7 @@ pub mod root {
         ["Offset of field: B::a"][::std::mem::offset_of!(B, a) - 0usize];
     };
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct StaticRefPtr {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/issue-674-3.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-3.rs
@@ -4,13 +4,13 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct nsRefPtrHashtable {
         pub _address: u8,
     }
     pub type nsRefPtrHashtable_UserDataType<PtrType> = *mut PtrType;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct a {
         pub b: u8,
     }
@@ -21,7 +21,7 @@ pub mod root {
         ["Offset of field: a::b"][::std::mem::offset_of!(a, b) - 0usize];
     };
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct nsCSSValue {
         pub c: root::a,
     }

--- a/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -2,7 +2,7 @@
 #[repr(C)]
 pub struct VirtualMethods__bindgen_vtable {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct VirtualMethods {
     pub vtable_: *const VirtualMethods__bindgen_vtable,
 }
@@ -21,12 +21,12 @@ impl Default for VirtualMethods {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Set {
     pub bar: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ServoElementSnapshotTable {
     pub _base: Set,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -1,16 +1,18 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(not(target_os = "windows"))]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -33,12 +35,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -60,12 +62,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -90,6 +92,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -128,6 +131,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -142,12 +146,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
@@ -309,7 +315,7 @@ impl Foo {
         foo: ::std::os::raw::c_ulong,
         bar: ::std::os::raw::c_ulong,
     ) -> __BindgenBitfieldUnit<[u8; 32usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 32usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 32usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/issue-743.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-743.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct S {
     pub p: *mut ::std::os::raw::c_void,
     pub b: bool,
@@ -210,7 +216,7 @@ impl S {
     pub fn new_bitfield_1(
         u: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Clone, Copy, Debug)]
     pub struct Rooted<T> {
         pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         pub member: T,

--- a/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -6,7 +6,7 @@ pub struct A {
 }
 #[repr(C)]
 #[repr(align(1))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct B {
     pub _bindgen_opaque_blob: u8,
 }
@@ -20,7 +20,7 @@ unsafe extern "C" {
     pub static mut B_a: A;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct C {
     pub b: B,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Pupper {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of Pupper"][::std::mem::align_of::<Pupper>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Doggo {
     pub _address: u8,
 }
@@ -20,7 +20,7 @@ const _: () = {
     ["Alignment of Doggo"][::std::mem::align_of::<Doggo>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct SuchWow {
     pub _address: u8,
 }
@@ -31,7 +31,7 @@ const _: () = {
 };
 #[repr(C)]
 #[repr(align(1))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Opaque {
     pub _bindgen_opaque_blob: u8,
 }
@@ -65,7 +65,7 @@ unsafe extern "C" {
     pub static mut Opaque_MAJESTIC_AF: Doggo;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Allowlisted {
     pub some_member: Opaque,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct capabilities {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
@@ -1677,7 +1683,7 @@ impl capabilities {
         bit_40: ::std::os::raw::c_uint,
         bit_41: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 16usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 16usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-833-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-833-2.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct nsTArray {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-834.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-834.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct U {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-848-replacement-system-include.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-848-replacement-system-include.rs
@@ -6,7 +6,7 @@
 
  <div rustbindgen replaces="nsTArray"></div>*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsTArray<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m: *mut T,

--- a/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Type {
             pub _address: u8,
         }

--- a/bindgen-tests/tests/expectations/tests/issue-946.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-946.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {}
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/issue_311.rs
+++ b/bindgen-tests/tests/expectations/tests/issue_311.rs
@@ -4,12 +4,12 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct jsval_layout {
         pub __bindgen_anon_1: root::jsval_layout__bindgen_ty_1,
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct jsval_layout__bindgen_ty_1 {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -232,7 +238,7 @@ pub enum JSWhyMagic {
     JS_WHY_MAGIC_COUNT = 18,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union jsval_layout {
     pub asBits: u64,
     pub debugView: jsval_layout__bindgen_ty_1,
@@ -243,7 +249,7 @@ pub union jsval_layout {
     pub asUIntPtr: usize,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct jsval_layout__bindgen_ty_1 {
     pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
@@ -344,7 +350,7 @@ impl jsval_layout__bindgen_ty_1 {
         payload47: u64,
         tag: JSValueTag,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 8usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -367,12 +373,12 @@ impl jsval_layout__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct jsval_layout__bindgen_ty_2 {
     pub payload: jsval_layout__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     pub i32_: i32,
     pub u32_: u32,
@@ -462,7 +468,7 @@ impl Default for jsval_layout {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct Value {
     pub data: jsval_layout,
 }

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -219,7 +225,7 @@ impl Default for rte_kni_fifo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct rte_eth_link {
     pub _bindgen_align: [u64; 0],
     ///< ETH_SPEED_NUM_
@@ -350,7 +356,7 @@ impl rte_eth_link {
         link_autoneg: u16,
         link_status: u16,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -17,7 +17,7 @@ pub const ARP_OP_INVREPLY: u32 = 9;
  administrator and does not contain OUIs.
  See http://standards.ieee.org/regauth/groupmac/tutorial.html*/
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ether_addr {
     ///< Addr bytes in tx order
     pub addr_bytes: [u8; 6usize],
@@ -32,7 +32,7 @@ const _: () = {
 };
 /// ARP header IPv4 payload.
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct arp_ipv4 {
     ///< sender hardware address
     pub arp_sha: ether_addr,
@@ -62,7 +62,7 @@ const _: () = {
 };
 /// ARP header.
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct arp_hdr {
     pub arp_hrd: u16,
     pub arp_pro: u16,

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
@@ -54,7 +54,7 @@ pub type rte_mempool_get_count = ::std::option::Option<
 /// Structure defining mempool operations structure
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_mempool_ops {
     ///< Name of mempool ops struct.
     pub name: [::std::os::raw::c_char; 32usize],
@@ -105,7 +105,7 @@ impl Default for rte_mempool_ops {
 }
 /// The rte_spinlock_t type.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_spinlock_t {
     ///< lock status 0 = unlocked, 1 = locked
     pub locked: ::std::os::raw::c_int,
@@ -127,7 +127,7 @@ const _: () = {
  This results in us simply having "ops_index" in the mempool struct.*/
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_mempool_ops_table {
     ///< Spinlock for add/delete.
     pub sl: rte_spinlock_t,
@@ -167,7 +167,7 @@ impl Default for rte_mempool_ops_table {
 /// Structure to hold malloc heap
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct malloc_heap {
     pub lock: rte_spinlock_t,
     pub free_head: [malloc_heap__bindgen_ty_1; 13usize],
@@ -175,7 +175,7 @@ pub struct malloc_heap {
     pub total_size: usize,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct malloc_heap__bindgen_ty_1 {
     pub lh_first: *mut malloc_elem,
 }
@@ -227,7 +227,7 @@ impl Default for malloc_heap {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct malloc_elem {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
@@ -18,7 +18,7 @@ pub enum _bindgen_ty_1 {
 }
 /// @internal fragmented mbuf
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ip_frag {
     ///< offset into the packet
     pub ofs: u16,
@@ -46,7 +46,7 @@ impl Default for ip_frag {
 }
 /// @internal <src addr, dst_addr, id> to uniquely indetify fragmented datagram.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ip_frag_key {
     ///< src address, first 8 bytes used for IPv4
     pub src_dst: [u64; 4usize],
@@ -73,7 +73,7 @@ const _: () = {
  First two entries in the frags[] array are for the last and first fragments.*/
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ip_frag_pkt {
     ///< LRU list
     pub lru: ip_frag_pkt__bindgen_ty_1,
@@ -91,7 +91,7 @@ pub struct ip_frag_pkt {
     pub frags: [ip_frag; 4usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ip_frag_pkt__bindgen_ty_1 {
     pub tqe_next: *mut ip_frag_pkt,
     pub tqe_prev: *mut *mut ip_frag_pkt,
@@ -157,7 +157,7 @@ impl Default for ip_frag_pkt {
 }
 ///< fragment mbuf
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mbuf {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
@@ -2,7 +2,7 @@
 /** Stores a pointer to the ops struct, and the offset: the place to
  write the parsed result in the destination structure.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct cmdline_token_hdr {
     pub ops: *mut cmdline_token_ops,
     pub offset: ::std::os::raw::c_uint,
@@ -50,7 +50,7 @@ pub type cmdline_parse_token_hdr_t = cmdline_token_hdr;
  get_help() fills the dstbuf with the help for the token. It returns
  -1 on error and 0 on success.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct cmdline_token_ops {
     /// parse(token ptr, buf, res pts, buf len)
     pub parse: ::std::option::Option<
@@ -117,7 +117,7 @@ pub enum cmdline_numtype {
     INT64 = 7,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct cmdline_token_num_data {
     pub type_: cmdline_numtype,
 }
@@ -143,7 +143,7 @@ impl Default for cmdline_token_num_data {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct cmdline_token_num {
     pub hdr: cmdline_token_hdr,
     pub num_data: cmdline_token_num_data,

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -201,7 +207,7 @@ pub enum rte_eth_rx_mq_mode {
 }
 /// A structure used to configure the RX features of an Ethernet port.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_rxmode {
     /// The multi-queue packet distribution mode to be used, e.g. RSS.
     pub mq_mode: rte_eth_rx_mq_mode,
@@ -571,7 +577,7 @@ impl rte_eth_rxmode {
         enable_scatter: u16,
         enable_lro: u16,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -686,7 +692,7 @@ pub enum rte_eth_tx_mq_mode {
 }
 /// A structure used to configure the TX features of an Ethernet port.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_txmode {
     ///< TX multi-queues mode.
     pub mq_mode: rte_eth_tx_mq_mode,
@@ -826,7 +832,7 @@ impl rte_eth_txmode {
         hw_vlan_reject_untagged: u8,
         hw_vlan_insert_pvid: u8,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -879,7 +885,7 @@ impl rte_eth_txmode {
  types of IPv4/IPv6 packets to which the RSS hashing must be applied.
  Supplying an *rss_hf* equal to zero disables the RSS feature.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_rss_conf {
     ///< If not NULL, 40-byte hash key.
     pub rss_key: *mut u8,
@@ -947,7 +953,7 @@ pub enum rte_eth_nb_pools {
  A default pool may be used, if desired, to route all traffic which
  does not match the vlan filter rules.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_dcb_conf {
     ///< With DCB, 16 or 32 pools
     pub nb_queue_pools: rte_eth_nb_pools,
@@ -962,7 +968,7 @@ pub struct rte_eth_vmdq_dcb_conf {
     pub dcb_tc: [u8; 8usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
     ///< The vlan ID of the received frame
     pub vlan_id: u16,
@@ -1021,7 +1027,7 @@ impl Default for rte_eth_vmdq_dcb_conf {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_dcb_rx_conf {
     ///< Possible DCB TCs, 4 or 8 TCs
     pub nb_tcs: rte_eth_nb_tcs,
@@ -1053,7 +1059,7 @@ impl Default for rte_eth_dcb_rx_conf {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_dcb_tx_conf {
     ///< With DCB, 16 or 32 pools.
     pub nb_queue_pools: rte_eth_nb_pools,
@@ -1085,7 +1091,7 @@ impl Default for rte_eth_vmdq_dcb_tx_conf {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_dcb_tx_conf {
     ///< Possible DCB TCs, 4 or 8 TCs.
     pub nb_tcs: rte_eth_nb_tcs,
@@ -1117,7 +1123,7 @@ impl Default for rte_eth_dcb_tx_conf {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_tx_conf {
     ///< VMDq mode, 64 pools.
     pub nb_queue_pools: rte_eth_nb_pools,
@@ -1144,7 +1150,7 @@ impl Default for rte_eth_vmdq_tx_conf {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_rx_conf {
     ///< VMDq only mode, 8 or 64 pools
     pub nb_queue_pools: rte_eth_nb_pools,
@@ -1162,7 +1168,7 @@ pub struct rte_eth_vmdq_rx_conf {
     pub pool_map: [rte_eth_vmdq_rx_conf__bindgen_ty_1; 64usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_vmdq_rx_conf__bindgen_ty_1 {
     ///< The vlan ID of the received frame
     pub vlan_id: u16,
@@ -1263,7 +1269,7 @@ pub enum rte_fdir_status_mode {
 }
 /// A structure used to define the input for IPV4 flow
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_ipv4_flow {
     ///< IPv4 source address in big endian.
     pub src_ip: u32,
@@ -1300,7 +1306,7 @@ const _: () = {
 };
 /// A structure used to define the input for IPV6 flow
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_ipv6_flow {
     ///< IPv6 source address in big endian.
     pub src_ip: [u32; 4usize],
@@ -1338,7 +1344,7 @@ const _: () = {
 /**  A structure used to configure FDIR masks that are used by the device
   to match the various fields of RX packet headers.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_fdir_masks {
     ///< Bit mask for vlan_tci in big endian
     pub vlan_tci_mask: u16,
@@ -1406,7 +1412,7 @@ pub enum rte_eth_payload_type {
 /** A structure used to select bytes extracted from the protocol layers to
  flexible payload for filter*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_flex_payload_cfg {
     ///< Payload type
     pub type_: rte_eth_payload_type,
@@ -1439,7 +1445,7 @@ impl Default for rte_eth_flex_payload_cfg {
 /** A structure used to define FDIR masks for flexible payload
  for each flow type*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_eth_fdir_flex_mask {
     pub flow_type: u16,
     pub mask: [u8; 16usize],
@@ -1462,7 +1468,7 @@ const _: () = {
 /** A structure used to define all flexible payload related setting
  include flex payload and flex mask*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_fdir_flex_conf {
     ///< The number of following payload cfg
     pub nb_payloads: u16,
@@ -1506,7 +1512,7 @@ impl Default for rte_eth_fdir_flex_conf {
 
  If mode is RTE_FDIR_DISABLE, the pballoc value is ignored.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_fdir_conf {
     ///< Flow Director mode.
     pub mode: rte_fdir_mode,
@@ -1553,7 +1559,7 @@ impl Default for rte_fdir_conf {
 }
 /// A structure used to enable/disable specific device interrupts.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_intr_conf {
     /// enable/disable lsc interrupt. 0 (default) - disable, 1 enable
     pub lsc: u16,
@@ -1575,7 +1581,7 @@ const _: () = {
  Depending upon the RX multi-queue mode, extra advanced
  configuration settings may be needed.*/
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_eth_conf {
     /**< bitmap of ETH_LINK_SPEED_XXX of speeds to be
 used. ETH_LINK_SPEED_FIXED disables link
@@ -1608,7 +1614,7 @@ is needed,and the variable must be set ETH_DCB_PFC_SUPPORT.*/
     pub intr_conf: rte_intr_conf,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct rte_eth_conf__bindgen_ty_1 {
     ///< Port RSS configuration
     pub rss_conf: rte_eth_rss_conf,
@@ -1647,7 +1653,7 @@ impl Default for rte_eth_conf__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_eth_conf__bindgen_ty_2 {
     pub vmdq_dcb_tx_conf: rte_eth_vmdq_dcb_tx_conf,
     pub dcb_tx_conf: rte_eth_dcb_tx_conf,

--- a/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
@@ -3,7 +3,7 @@ pub const RTE_CACHE_LINE_MIN_SIZE: u32 = 64;
 pub const RTE_CACHE_LINE_SIZE: u32 = 64;
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct rte_kni_mbuf {
     pub buf_addr: *mut ::std::os::raw::c_void,
     pub buf_physaddr: u64,

--- a/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Debug)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
@@ -56,7 +56,7 @@ pub enum _bindgen_ty_1 {
 }
 /// @internal fragmented mbuf
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ip_frag {
     ///< offset into the packet
     pub ofs: u16,
@@ -84,7 +84,7 @@ impl Default for ip_frag {
 }
 /// @internal <src addr, dst_addr, id> to uniquely indetify fragmented datagram.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ip_frag_key {
     ///< src address, first 8 bytes used for IPv4
     pub src_dst: [u64; 4usize],
@@ -111,7 +111,7 @@ const _: () = {
  First two entries in the frags[] array are for the last and first fragments.*/
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ip_frag_pkt {
     ///< LRU list
     pub lru: ip_frag_pkt__bindgen_ty_1,
@@ -129,7 +129,7 @@ pub struct ip_frag_pkt {
     pub frags: [ip_frag; 4usize],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ip_frag_pkt__bindgen_ty_1 {
     pub tqe_next: *mut ip_frag_pkt,
     pub tqe_prev: *mut *mut ip_frag_pkt,
@@ -194,7 +194,7 @@ impl Default for ip_frag_pkt {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ip_pkt_list {
     pub tqh_first: *mut ip_frag_pkt,
     pub tqh_last: *mut *mut ip_frag_pkt,
@@ -222,7 +222,7 @@ impl Default for ip_pkt_list {
 /// fragmentation table statistics
 #[repr(C)]
 #[repr(align(64))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct ip_frag_tbl_stat {
     ///< total # of find/insert attempts.
     pub find_num: u64,
@@ -351,7 +351,7 @@ impl Default for rte_ip_frag_tbl {
 }
 ///< fragment mbuf
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct rte_mbuf {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -153,7 +159,7 @@ pub type MARKER8 = [u8; 0usize];
 pub type MARKER64 = [u64; 0usize];
 /// The atomic counter structure.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_atomic16_t {
     ///< An internal counter value.
     pub cnt: i16,
@@ -220,7 +226,7 @@ pub struct rte_mbuf {
  or non-atomic) is controlled by the CONFIG_RTE_MBUF_REFCNT_ATOMIC
  config option.*/
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_1 {
     ///< Atomically accessed refcnt
     pub refcnt_atomic: rte_atomic16_t,
@@ -252,14 +258,14 @@ impl Default for rte_mbuf__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_2 {
     ///< L2/L3/L4 and tunnel information.
     pub packet_type: u32,
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -536,7 +542,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         inner_l3_type: u32,
         inner_l4_type: u32,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -631,7 +637,7 @@ impl Default for rte_mbuf__bindgen_ty_2 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_3 {
     ///< RSS hash result if RSS enabled
     pub rss: u32,
@@ -643,19 +649,19 @@ pub union rte_mbuf__bindgen_ty_3 {
     pub usr: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
     pub hi: u32,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
     pub lo: u32,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
     pub hash: u16,
     pub id: u16,
@@ -729,7 +735,7 @@ impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
     pub lo: u32,
     pub hi: u32,
@@ -780,7 +786,7 @@ impl Default for rte_mbuf__bindgen_ty_3 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_4 {
     ///< Can be used for external metadata
     pub userdata: *mut ::std::os::raw::c_void,
@@ -812,14 +818,14 @@ impl Default for rte_mbuf__bindgen_ty_4 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union rte_mbuf__bindgen_ty_5 {
     ///< combined for easy fetch
     pub tx_offload: u64,
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
@@ -1060,7 +1066,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         outer_l3_len: u64,
         outer_l2_len: u64,
     ) -> __BindgenBitfieldUnit<[u8; 7usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 7usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 7usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -1222,7 +1228,7 @@ impl Default for rte_mbuf {
 }
 ///< Pool from which mbuf was allocated.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct rte_mempool {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
@@ -1,17 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct B {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub _address: u8,
 }
 pub type C_U = B;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub u: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-544-stylo-creduce-2.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,7 +7,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Foo {
     pub member: *mut __BindgenOpaqueArray<[u8; 0usize]>,
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct TEST_STRUCT {
     pub ptr_32bit: *mut ::std::os::raw::c_void,
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
@@ -31,7 +31,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct _bindgen_ty_1 {
             pub foo: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/long_double.rs
+++ b/bindgen-tests/tests/expectations/tests/long_double.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub bar: u128,
 }

--- a/bindgen-tests/tests/expectations/tests/maddness-is-avoidable.rs
+++ b/bindgen-tests/tests/expectations/tests/maddness-is-avoidable.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RefPtr {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn foo();
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn foo();
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-macos.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-macos.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn foo();
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win32.rs
@@ -4,7 +4,7 @@ unsafe extern "C" {
     pub fn foo();
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-win64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win64.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn foo();
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/merge_extern_blocks_post_1_82.rs
+++ b/bindgen-tests/tests/expectations/tests/merge_extern_blocks_post_1_82.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Point {
         pub x: ::std::os::raw::c_int,
     }
@@ -18,7 +18,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Point {
             pub x: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/merge_extern_blocks_pre_1_82.rs
+++ b/bindgen-tests/tests/expectations/tests/merge_extern_blocks_pre_1_82.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Point {
         pub x: ::std::os::raw::c_int,
     }
@@ -18,7 +18,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Point {
             pub x: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Test {
         pub _address: u8,
     }

--- a/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
+++ b/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub foo: usize,
 }

--- a/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }
@@ -20,7 +20,7 @@ const _: () = {
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Baz {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/mutable.rs
+++ b/bindgen-tests/tests/expectations/tests/mutable.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub m_member: ::std::os::raw::c_int,
     pub m_other: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -21,7 +21,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct A {
             pub b: root::whatever::whatever_int_t,
         }

--- a/bindgen-tests/tests/expectations/tests/nested-class-field.rs
+++ b/bindgen-tests/tests/expectations/tests/nested-class-field.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub _address: u8,
 }
@@ -10,7 +10,7 @@ const _: () = {
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A_I {
     pub i: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/nested-template-typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/nested-template-typedef.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo_Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/nested.rs
+++ b/bindgen-tests/tests/expectations/tests/nested.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Calc {
     pub w: ::std::os::raw::c_int,
 }
@@ -11,18 +11,18 @@ const _: () = {
     ["Offset of field: Calc::w"][::std::mem::offset_of!(Calc, w) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test_Size {
     pub mWidth: Test_Size_Dimension,
     pub mHeight: Test_Size_Dimension,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test_Size_Dimension {
     pub _base: Calc,
 }

--- a/bindgen-tests/tests/expectations/tests/nested_vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_vtable.rs
@@ -6,7 +6,7 @@ pub struct nsISupports__bindgen_vtable {
     ) -> *mut nsISupports,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsISupports {
     pub vtable_: *const nsISupports__bindgen_vtable,
 }
@@ -31,7 +31,7 @@ unsafe extern "C" {
     ) -> *mut nsISupports;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsIRunnable {
     pub _base: nsISupports,
 }
@@ -50,7 +50,7 @@ impl Default for nsIRunnable {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Runnable {
     pub _base: nsIRunnable,
 }

--- a/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
@@ -7,12 +7,12 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Bar {
             pub foo: ::std::os::raw::c_int,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Bar_Baz {
             pub foo: ::std::os::raw::c_int,
         }
@@ -31,7 +31,7 @@ pub mod root {
             ["Offset of field: Bar::foo"][::std::mem::offset_of!(Bar, foo) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Baz {
             pub baz: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/no-comments.rs
+++ b/bindgen-tests/tests/expectations/tests/no-comments.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub s: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoHash {
     pub i: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoHash {
     pub _bindgen_opaque_blob: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoPartialEq {
     pub i: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct NoPartialEq {
     pub _bindgen_opaque_blob: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub enum Bar {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Foo {
     pub baz: *mut Bar,
 }

--- a/bindgen-tests/tests/expectations/tests/no-std.rs
+++ b/bindgen-tests/tests/expectations/tests/no-std.rs
@@ -5,7 +5,7 @@ mod libc {
     pub enum c_void {}
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct foo {
     pub a: libc::c_int,
     pub b: libc::c_int,

--- a/bindgen-tests/tests/expectations/tests/no_debug.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen nodebug></div>
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct DebugButWait {
     pub whatever: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct NoDebug {
     pub i: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Default, Copy, Clone)]
+#[derive(Clone, Copy, Default)]
 pub struct NoDebug {
     pub _bindgen_opaque_blob: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/no_default.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen nodefault></div>
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DefaultButWait {
     pub whatever: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DefaultButWaitDerived {
     pub whatever: DefaultButWait,
 }

--- a/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoDefault {
     pub i: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct NoDefault {
     pub _bindgen_opaque_blob: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
+++ b/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
@@ -2,7 +2,7 @@
 pub type size_t = ::std::os::raw::c_ulong;
 pub type ssize_t = ::std::os::raw::c_long;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct A {
     pub len: size_t,
     pub offset: ssize_t,

--- a/bindgen-tests/tests/expectations/tests/non-type-params.rs
+++ b/bindgen-tests/tests/expectations/tests/non-type-params.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -10,7 +10,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
 pub type Array16 = u8;
 pub type ArrayInt4 = __BindgenOpaqueArray<[u32; 4usize]>;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct UsesArray {
     pub array_char_16: __BindgenOpaqueArray<[u8; 16usize]>,
     pub array_bool_8: __BindgenOpaqueArray<[u8; 8usize]>,

--- a/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,24 +7,24 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct nsBaseHashtableET {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct nsTHashtable {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsBaseHashtable {
     pub _address: u8,
 }
 pub type nsBaseHashtable_KeyType = __BindgenOpaqueArray<[u8; 0usize]>;
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsBaseHashtable_LookupResult {
     pub mEntry: *mut nsBaseHashtable_EntryType,
     pub mTable: *mut nsBaseHashtable,

--- a/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsTArray<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub mBuff: *mut T,
@@ -15,7 +15,7 @@ impl<T> Default for nsTArray<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsStyleAutoArray<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub mFirstElement: T,

--- a/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
@@ -21,7 +21,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct FooStruct {
     pub foo: Foo,
 }

--- a/bindgen-tests/tests/expectations/tests/objc_template.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_template.rs
@@ -3,7 +3,6 @@
 use objc::{self, msg_send, sel, sel_impl, class};
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
@@ -228,7 +234,7 @@ impl C {
     }
     #[inline]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -2,13 +2,13 @@
 /** This is like `opaque-template-inst-member.hpp` except exercising the cases
  where we are OK to derive Debug/Hash/PartialEq.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct OpaqueTemplate {
     pub _address: u8,
 }
 /// Should derive Debug/Hash/PartialEq.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ContainsOpaqueTemplate {
     pub mBlah: u32,
     pub mBaz: ::std::os::raw::c_int,
@@ -30,7 +30,7 @@ const _: () = {
 };
 /// Should also derive Debug/Hash/PartialEq.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct InheritsOpaqueTemplate {
     pub _base: u8,
     pub wow: *mut ::std::os::raw::c_char,

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,14 +8,14 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct OpaqueTemplate {
     pub _address: u8,
 }
 /** This should not end up deriving Debug/Hash because its `mBlah` field cannot derive
  Debug/Hash because the instantiation's definition cannot derive Debug/Hash.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ContainsOpaqueTemplate {
     pub mBlah: __BindgenOpaqueArray<[u32; 101usize]>,
     pub mBaz: ::std::os::raw::c_int,
@@ -38,7 +38,7 @@ const _: () = {
 /** This should not end up deriving Debug/Hash either, for similar reasons, although
  we're exercising base member edges now.*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct InheritsOpaqueTemplate {
     pub _base: __BindgenOpaqueArray<[u8; 401usize]>,
     pub wow: *mut ::std::os::raw::c_char,

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct Template<T> {
             pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
             pub member: T,
@@ -22,7 +22,7 @@ pub mod root {
             }
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct Foo {
             pub c: ::std::os::raw::c_char,
         }
@@ -33,7 +33,7 @@ pub mod root {
             ["Offset of field: Foo::c"][::std::mem::offset_of!(Foo, c) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct Bar {
             pub i: ::std::os::raw::c_int,
         }
@@ -44,7 +44,7 @@ pub mod root {
             ["Offset of field: Bar::i"][::std::mem::offset_of!(Bar, i) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct ContainsInstantiation {
             pub not_opaque: root::zoidberg::Template<root::zoidberg::Foo>,
         }
@@ -70,7 +70,7 @@ pub mod root {
             }
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct ContainsOpaqueInstantiation {
             pub opaque: u32,
         }

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Template<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member: T,
@@ -15,7 +15,7 @@ impl<T> Default for Template<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ContainsInstantiation {
     pub not_opaque: Template<::std::os::raw::c_char>,
 }
@@ -41,7 +41,7 @@ impl Default for ContainsInstantiation {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct ContainsOpaqueInstantiation {
     pub opaque: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
@@ -5,7 +5,7 @@ unsafe extern "C" {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Container {
     pub _bindgen_opaque_blob: [u32; 2usize],
 }

--- a/bindgen-tests/tests/expectations/tests/opaque_array_union_derives.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_array_union_derives.rs
@@ -1,0 +1,95 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
+/// <div rustbindgen derive="PartialEq"></div>
+#[repr(C)]
+#[repr(align(64))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct first_struct {
+    pub x: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: __BindgenOpaqueArray<[u8; 60usize]>,
+    pub padding_to_align: [::std::os::raw::c_char; 60usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of first_struct"][::std::mem::size_of::<first_struct>() - 128usize];
+    ["Alignment of first_struct"][::std::mem::align_of::<first_struct>() - 64usize];
+    [
+        "Offset of field: first_struct::x",
+    ][::std::mem::offset_of!(first_struct, x) - 0usize];
+    [
+        "Offset of field: first_struct::padding_to_align",
+    ][::std::mem::offset_of!(first_struct, padding_to_align) - 64usize];
+};
+impl Default for first_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+/// <div rustbindgen derive="PartialEq, Eq"></div>
+#[repr(C)]
+#[repr(align(64))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct second_struct {
+    pub y: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: __BindgenOpaqueArray<[u8; 60usize]>,
+    pub more_padding: [::std::os::raw::c_char; 60usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of second_struct"][::std::mem::size_of::<second_struct>() - 128usize];
+    ["Alignment of second_struct"][::std::mem::align_of::<second_struct>() - 64usize];
+    [
+        "Offset of field: second_struct::y",
+    ][::std::mem::offset_of!(second_struct, y) - 0usize];
+    [
+        "Offset of field: second_struct::more_padding",
+    ][::std::mem::offset_of!(second_struct, more_padding) - 64usize];
+};
+impl Default for second_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
+#[repr(align(64))]
+#[derive(Clone, Copy, Debug)]
+pub struct third_struct {
+    pub z: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: __BindgenOpaqueArray<[u8; 60usize]>,
+    pub final_padding: [::std::os::raw::c_char; 60usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of third_struct"][::std::mem::size_of::<third_struct>() - 128usize];
+    ["Alignment of third_struct"][::std::mem::align_of::<third_struct>() - 64usize];
+    [
+        "Offset of field: third_struct::z",
+    ][::std::mem::offset_of!(third_struct, z) - 0usize];
+    [
+        "Offset of field: third_struct::final_padding",
+    ][::std::mem::offset_of!(third_struct, final_padding) - 64usize];
+};
+impl Default for third_struct {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
@@ -2,7 +2,7 @@
 /// <div rustbindgen opaque>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct opaque {
     pub _bindgen_opaque_blob: u32,
 }
@@ -12,7 +12,7 @@ const _: () = {
     ["Alignment of opaque"][::std::mem::align_of::<opaque>() - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct container {
     pub contained: opaque,
 }

--- a/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
@@ -2,7 +2,7 @@
 /// <div rustbindgen opaque></div>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct OtherOpaque {
     pub _bindgen_opaque_blob: u32,
 }
@@ -13,12 +13,12 @@ const _: () = {
 };
 /// <div rustbindgen opaque></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Opaque {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq)]
 pub struct WithOpaquePtr {
     pub whatever: *mut u8,
     pub other: u32,

--- a/bindgen-tests/tests/expectations/tests/opaque_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_typedef.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct RandomTemplate {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/operator_equals.rs
+++ b/bindgen-tests/tests/expectations/tests/operator_equals.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct SomeClass {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Date {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
@@ -268,7 +274,7 @@ impl Date {
         month: ::std::os::raw::c_uchar,
         year: ::std::os::raw::c_short,
     ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 3usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C, packed(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Packed {
     pub a: ::std::os::raw::c_char,
     pub b: ::std::os::raw::c_short,

--- a/bindgen-tests/tests/expectations/tests/parm-union.rs
+++ b/bindgen-tests/tests/expectations/tests/parm-union.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Struct {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,17 +7,17 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Base {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Derived {
     pub b: bool,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Usage {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/private.rs
+++ b/bindgen-tests/tests/expectations/tests/private.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct HasPrivate {
     pub mNotPrivate: ::std::os::raw::c_int,
     /// <div rustbindgen private></div>
@@ -19,7 +19,7 @@ const _: () = {
 };
 /// <div rustbindgen private></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct VeryPrivate {
     mIsPrivate: ::std::os::raw::c_int,
     mIsAlsoPrivate: ::std::os::raw::c_int,
@@ -37,7 +37,7 @@ const _: () = {
 };
 /// <div rustbindgen private></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ContradictPrivate {
     /// <div rustbindgen private="false"></div>
     pub mNotPrivate: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PubPriv {
     pub x: ::std::os::raw::c_int,
     y: ::std::os::raw::c_int,
@@ -159,7 +165,7 @@ const _: () = {
     ["Offset of field: PubPriv::y"][::std::mem::offset_of!(PubPriv, y) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PrivateBitFields {
     pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -250,7 +256,7 @@ impl PrivateBitFields {
         a: ::std::os::raw::c_uint,
         b: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -273,7 +279,7 @@ impl PrivateBitFields {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct PublicBitFields {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -362,7 +368,7 @@ impl PublicBitFields {
         a: ::std::os::raw::c_uint,
         b: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -385,7 +391,7 @@ impl PublicBitFields {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct MixedBitFields {
     pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -474,7 +480,7 @@ impl MixedBitFields {
         a: ::std::os::raw::c_uint,
         d: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -497,7 +503,7 @@ impl MixedBitFields {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Base {
     pub member: ::std::os::raw::c_int,
 }
@@ -508,7 +514,7 @@ const _: () = {
     ["Offset of field: Base::member"][::std::mem::offset_of!(Base, member) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct InheritsPrivately {
     _base: Base,
 }
@@ -520,7 +526,7 @@ const _: () = {
     ][::std::mem::align_of::<InheritsPrivately>() - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct InheritsPublically {
     pub _base: Base,
 }
@@ -532,13 +538,13 @@ const _: () = {
     ][::std::mem::align_of::<InheritsPublically>() - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithAnonStruct {
     __bindgen_anon_1: WithAnonStruct__bindgen_ty_1,
     pub __bindgen_anon_2: WithAnonStruct__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithAnonStruct__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
 }
@@ -555,7 +561,7 @@ const _: () = {
     ][::std::mem::offset_of!(WithAnonStruct__bindgen_ty_1, a) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WithAnonStruct__bindgen_ty_2 {
     pub b: ::std::os::raw::c_int,
 }
@@ -577,12 +583,12 @@ const _: () = {
     ["Alignment of WithAnonStruct"][::std::mem::align_of::<WithAnonStruct>() - 4usize];
 };
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct WithAnonUnion {
     __bindgen_anon_1: WithAnonUnion__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union WithAnonUnion__bindgen_ty_1 {
     pub _address: u8,
 }
@@ -619,7 +625,7 @@ impl Default for WithAnonUnion {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Override {
     pub a: ::std::os::raw::c_uint,
     /// <div rustbindgen private></div>
@@ -753,7 +759,7 @@ impl Override {
         bf_b: ::std::os::raw::c_uint,
         private_bf_c: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct TEST_STRUCT {
     pub ptr_32bit: u32,
 }

--- a/bindgen-tests/tests/expectations/tests/qualified-dependent-types.rs
+++ b/bindgen-tests/tests/expectations/tests/qualified-dependent-types.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
+++ b/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,13 +145,15 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
 #[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct redundant_packed {
     pub a: u32,
     pub b: u32,
@@ -166,7 +172,7 @@ const _: () = {
     ][::std::mem::offset_of!(redundant_packed, b) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct redundant_packed_bitfield {
     pub _bindgen_align: [u64; 0],
     pub a: [u8; 3usize],
@@ -261,7 +267,7 @@ impl redundant_packed_bitfield {
     }
     #[inline]
     pub fn new_bitfield_1(b0: u8, b1: u8) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -285,7 +291,7 @@ impl redundant_packed_bitfield {
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union redundant_packed_union {
     pub a: u64,
     pub b: u32,
@@ -316,7 +322,7 @@ impl Default for redundant_packed_union {
 }
 #[repr(C)]
 #[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct inner {
     pub a: u8,
 }
@@ -328,7 +334,7 @@ const _: () = {
 };
 #[repr(C)]
 #[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct outer_redundant_packed {
     pub a: [inner; 2usize],
     pub b: u32,
@@ -350,7 +356,7 @@ const _: () = {
 };
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct redundant_pragma_packed {
     pub a: u8,
     pub b: u16,

--- a/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
+++ b/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
@@ -8,7 +8,7 @@ pub struct nsID__bindgen_vtable {
     ),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct nsID {
     pub vtable_: *const nsID__bindgen_vtable,
 }

--- a/bindgen-tests/tests/expectations/tests/references.rs
+++ b/bindgen-tests/tests/expectations/tests/references.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Container {
     pub normalPointer: *mut ::std::os::raw::c_int,
     pub constPointer: *const ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
+++ b/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
@@ -8,7 +8,7 @@ pub mod root {
         use self::super::super::root;
         /// <div rustbindgen replaces="foo::Bar"></div>
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Bar {
             pub bazz: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
@@ -4,7 +4,7 @@
  <div rustbindgen replaces="JS::detail::MaybeWrapped" />*/
 pub type JS_detail_MaybeWrapped<T> = T;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct JS_Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: JS_detail_MaybeWrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/replace_use.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_use.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 /// <div rustbindgen replaces="nsTArray"></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct nsTArray {
     pub y: ::std::os::raw::c_uint,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Test {
     pub a: nsTArray,
 }

--- a/bindgen-tests/tests/expectations/tests/replaces_double.rs
+++ b/bindgen-tests/tests/expectations/tests/replaces_double.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Wrapper_Wrapped<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
@@ -16,7 +16,7 @@ impl<T> Default for Wrapper_Wrapped<T> {
 }
 pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: Rooted_MaybeWrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/repr-align.rs
+++ b/bindgen-tests/tests/expectations/tests/repr-align.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "nightly")]
 #[repr(C)]
 #[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct a {
     pub b: ::std::os::raw::c_int,
     pub c: ::std::os::raw::c_int,
@@ -16,7 +16,7 @@ const _: () = {
 };
 #[repr(C)]
 #[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct b {
     pub b: ::std::os::raw::c_int,
     pub c: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -5,7 +5,7 @@ pub struct JS_Zone {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct JS_shadow_Zone {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -7,17 +7,17 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Wrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Wrapper_sentry {
             pub i_am_wrapper_sentry: ::std::os::raw::c_int,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct sentry {
             pub i_am_plain_sentry: bool,
         }
@@ -30,7 +30,7 @@ pub mod root {
             ][::std::mem::offset_of!(sentry, i_am_plain_sentry) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct NotTemplateWrapper {
             pub _address: u8,
         }
@@ -44,7 +44,7 @@ pub mod root {
             ][::std::mem::align_of::<NotTemplateWrapper>() - 1usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct NotTemplateWrapper_sentry {
             pub i_am_not_template_wrapper_sentry: ::std::os::raw::c_char,
         }
@@ -63,12 +63,12 @@ pub mod root {
             ) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct InlineNotTemplateWrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct InlineNotTemplateWrapper_sentry {
             pub i_am_inline_not_template_wrapper_sentry: bool,
         }
@@ -96,22 +96,22 @@ pub mod root {
             ][::std::mem::align_of::<InlineNotTemplateWrapper>() - 1usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct InlineTemplateWrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct InlineTemplateWrapper_sentry {
             pub i_am_inline_template_wrapper_sentry: ::std::os::raw::c_int,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleWrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper {
             pub _address: u8,
         }
@@ -134,7 +134,7 @@ pub mod root {
             ][::std::mem::align_of::<OuterDoubleWrapper>() - 1usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper_sentry {
             pub i_am_double_wrapper_sentry: ::std::os::raw::c_int,
         }
@@ -155,17 +155,17 @@ pub mod root {
             ) - 0usize];
         };
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleInlineWrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper {
             pub _address: u8,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry {
             pub i_am_double_wrapper_inline_sentry: ::std::os::raw::c_int,
         }
@@ -210,17 +210,17 @@ pub mod root {
         };
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct OutsideNamespaceWrapper {
         pub _address: u8,
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct OutsideNamespaceWrapper_sentry {
         pub i_am_outside_namespace_wrapper_sentry: ::std::os::raw::c_int,
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct sentry {
         pub i_am_outside_namespace_sentry: ::std::os::raw::c_int,
     }

--- a/bindgen-tests/tests/expectations/tests/size_t_template.rs
+++ b/bindgen-tests/tests/expectations/tests/size_t_template.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct __BindgenOpaqueArray<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
@@ -8,7 +8,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]>
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct C {
     pub arr: __BindgenOpaqueArray<[u32; 3usize]>,
 }

--- a/bindgen-tests/tests/expectations/tests/sorted_items.rs
+++ b/bindgen-tests/tests/expectations/tests/sorted_items.rs
@@ -3,13 +3,13 @@
 pub mod root {
     pub type number = ::std::os::raw::c_int;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Point {
         pub x: root::number,
         pub y: root::number,
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct Angle {
         pub a: root::number,
         pub b: root::number,
@@ -32,13 +32,13 @@ pub mod root {
     pub mod ns {
         pub type number = ::std::os::raw::c_int;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Point {
             pub x: root::ns::number,
             pub y: root::ns::number,
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Clone, Copy, Debug, Default)]
         pub struct Angle {
             pub a: root::ns::number,
             pub b: root::ns::number,

--- a/bindgen-tests/tests/expectations/tests/specific_receiver.rs
+++ b/bindgen-tests/tests/expectations/tests/specific_receiver.rs
@@ -4,7 +4,7 @@ pub struct Fish__bindgen_vtable {
     pub Fish_swim: unsafe extern "C" fn(this: *mut Fish),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Fish {
     pub vtable_: *const Fish__bindgen_vtable,
 }

--- a/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
@@ -3,7 +3,7 @@ unsafe extern "C" {
     pub fn fun() -> u64;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Struct {
     pub field: u64,
 }

--- a/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct a {
     pub val_a: *mut b,
 }
@@ -20,7 +20,7 @@ impl Default for a {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct b {
     pub val_b: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/struct_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct typedef_named_struct {
     pub has_name: bool,
 }
@@ -17,7 +17,7 @@ const _: () = {
     ][::std::mem::offset_of!(typedef_named_struct, has_name) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct _bindgen_ty_1 {
     pub no_name: *mut ::std::os::raw::c_void,
 }

--- a/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
@@ -7,7 +7,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
@@ -31,7 +31,7 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo {
     pub bar: [foo__bindgen_ty_1; 2usize],
     pub baz: [[[foo__bindgen_ty_2; 4usize]; 3usize]; 2usize],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
@@ -25,7 +25,7 @@ const _: () = {
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_2 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct foo {
     pub bar: *mut foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo {
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo {
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct bitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub e: ::std::os::raw::c_int,
@@ -310,7 +316,7 @@ impl bitfield {
         c: ::std::os::raw::c_ushort,
         d: ::std::os::raw::c_ushort,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -426,7 +432,7 @@ impl bitfield {
         f: ::std::os::raw::c_uint,
         g: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 8usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct LittleArray {
     pub a: [::std::os::raw::c_int; 32usize],
 }
@@ -11,7 +11,7 @@ const _: () = {
     ["Offset of field: LittleArray::a"][::std::mem::offset_of!(LittleArray, a) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BigArray {
     pub a: [::std::os::raw::c_int; 33usize],
 }
@@ -31,7 +31,7 @@ impl Default for BigArray {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct WithLittleArray {
     pub a: LittleArray,
 }
@@ -44,7 +44,7 @@ const _: () = {
     ][::std::mem::offset_of!(WithLittleArray, a) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct WithBigArray {
     pub a: BigArray,
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct S {
     pub large_array: [::std::os::raw::c_char; 33usize],
 }
@@ -20,7 +20,7 @@ impl Default for S {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ST<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub large_array: [T; 33usize],

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
@@ -1,19 +1,19 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo {
     pub a: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub b: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: foo__bindgen_ty_1__bindgen_ty_1,
     pub __bindgen_anon_2: foo__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1__bindgen_ty_1 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
@@ -34,7 +34,7 @@ const _: () = {
     ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_1, c2) - 2usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1__bindgen_ty_2 {
     pub d1: ::std::os::raw::c_uchar,
     pub d2: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct a {
     pub b: ::std::os::raw::c_char,
     pub c: ::std::os::raw::c_short,

--- a/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub x: ::std::os::raw::c_uint,
     pub y: ::std::os::raw::c_uint,

--- a/bindgen-tests/tests/expectations/tests/struct_with_typedef_template_arg.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_typedef_template_arg.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Proxy {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/template-fun-ty.rs
+++ b/bindgen-tests/tests/expectations/tests/template-fun-ty.rs
@@ -1,17 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Foo {
     pub _address: u8,
 }
 pub type Foo_FunctionPtr<T> = ::std::option::Option<unsafe extern "C" fn() -> T>;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct RefPtr {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct RefPtr_Proxy {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-0.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-0.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-1.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-1.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DoesNotUseTemplateParameter {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DoublyIndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
@@ -9,7 +9,7 @@ pub struct DoublyIndirectUsage<T, U> {
 pub type DoublyIndirectUsage_Aliased<T> = T;
 pub type DoublyIndirectUsage_Typedefed<U> = U;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-11.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-11.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DoesNotUseT {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-12.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-12.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct BaseUsesT<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: *mut T,
@@ -15,7 +15,7 @@ impl<T> Default for BaseUsesT<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CrtpUsesU<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub _base: BaseUsesT<CrtpUsesU<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-13.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-13.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct BaseIgnoresT {
     pub x: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CrtpUsesU<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub _base: BaseIgnoresT,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-14.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-14.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct BaseIgnoresT {
     pub x: ::std::os::raw::c_int,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CrtpIgnoresU {
     pub _base: BaseIgnoresT,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-15.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-15.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct BaseUsesT<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub usage: *mut T,
@@ -15,7 +15,7 @@ impl<T> Default for BaseUsesT<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct CrtpIgnoresU {
     pub _base: BaseUsesT<CrtpIgnoresU>,
     pub y: ::std::os::raw::c_int,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub also: T,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct UsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct UsesTemplateParameter_DoesNotUseTemplateParameters {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct IndirectlyUsesTemplateParameter<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub aliased: IndirectlyUsesTemplateParameter_Aliased<T>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-6.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-6.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DoesNotUseTemplateParameter {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DoesNotUseU<T, V> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct IndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct DoesNotUse {
     pub _address: u8,
 }
 pub type DoesNotUse_Aliased<T> = T;
 pub type DoesNotUse_Typedefed<U> = U;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DoesNotUse_IndirectUsage<T, U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,

--- a/bindgen-tests/tests/expectations/tests/template-with-var.rs
+++ b/bindgen-tests/tests/expectations/tests/template-with-var.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TemplateWithVar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/template.rs
+++ b/bindgen-tests/tests/expectations/tests/template.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Foo<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m_member: T,
@@ -17,7 +17,7 @@ impl<T> Default for Foo<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct B<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m_member: T,
@@ -41,7 +41,7 @@ pub struct mozilla_Foo {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct C {
     pub mB: B<::std::os::raw::c_uint>,
     pub mBConstPtr: B<*const ::std::os::raw::c_int>,
@@ -101,13 +101,13 @@ impl Default for C {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct D {
     pub m_foo: D_MyFoo,
 }
 pub type D_MyFoo = Foo<::std::os::raw::c_int>;
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct D_U<Z> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<Z>>,
     pub m_nested_foo: D_MyFoo,
@@ -132,7 +132,7 @@ impl Default for D {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub prev: *mut T,
@@ -149,7 +149,7 @@ impl<T> Default for Rooted<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RootedContainer {
     pub root: Rooted<*mut ::std::os::raw::c_void>,
 }
@@ -172,7 +172,7 @@ impl Default for RootedContainer {
 }
 pub type WithDtorIntFwd = WithDtor<::std::os::raw::c_int>;
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct WithDtor<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub member: T,
@@ -187,7 +187,7 @@ impl<T> Default for WithDtor<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct PODButContainsDtor {
     pub member: WithDtorIntFwd,
 }
@@ -212,12 +212,12 @@ impl Default for PODButContainsDtor {
 }
 /// <div rustbindgen opaque>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Opaque {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct POD {
     pub opaque_member: u32,
 }
@@ -231,7 +231,7 @@ const _: () = {
 };
 /// <div rustbindgen replaces="NestedReplaced"></div>
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct NestedReplaced<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub buff: *mut T,
@@ -246,7 +246,7 @@ impl<T> Default for NestedReplaced<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct NestedBase<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub buff: *mut T,
@@ -261,7 +261,7 @@ impl<T> Default for NestedBase<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct NestedContainer<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub c: T,
@@ -278,7 +278,7 @@ impl<T> Default for NestedContainer<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Incomplete<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub d: T,
@@ -293,7 +293,7 @@ impl<T> Default for Incomplete<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Untemplated {
     pub _address: u8,
 }
@@ -303,7 +303,7 @@ const _: () = {
     ["Alignment of Untemplated"][::std::mem::align_of::<Untemplated>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Templated {
     pub m_untemplated: Untemplated,
 }
@@ -312,7 +312,7 @@ pub struct Templated {
 
  <div rustbindgen replaces="ReplacedWithoutDestructor"></div>*/
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ReplacedWithoutDestructor<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub buff: *mut T,
@@ -327,7 +327,7 @@ impl<T> Default for ReplacedWithoutDestructor<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ShouldNotBeCopiable<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m_member: ReplacedWithoutDestructor<T>,
@@ -342,7 +342,7 @@ impl<T> Default for ShouldNotBeCopiable<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ShouldNotBeCopiableAsWell<U> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub m_member: ReplacedWithoutDestructorFwd<U>,
@@ -361,7 +361,7 @@ impl<U> Default for ShouldNotBeCopiableAsWell<U> {
 
  <div rustbindgen replaces="ReplacedWithoutDestructorFwd"></div>*/
 #[repr(C)]
-#[derive(Debug, Hash, PartialEq, Eq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 pub struct ReplacedWithoutDestructorFwd<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub buff: *mut T,

--- a/bindgen-tests/tests/expectations/tests/template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/template_alias.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type JS_detail_Wrapped<T> = T;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct JS_Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: JS_detail_Wrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/template_alias_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/template_alias_namespace.rs
@@ -12,7 +12,7 @@ pub mod root {
             pub type Wrapped<T> = T;
         }
         #[repr(C)]
-        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
         pub struct Rooted<T> {
             pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
             pub ptr: root::JS::detail::Wrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }
@@ -18,7 +18,7 @@ const _: () = {
     ][::std::mem::align_of::<Foo>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Baz {
     pub _address: u8,
 }
@@ -37,7 +37,7 @@ const _: () = {
     ][::std::mem::align_of::<Foo>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }
@@ -47,7 +47,7 @@ const _: () = {
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Boo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct Wrapper {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Wrapper_Wrapped<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub t: T,

--- a/bindgen-tests/tests/expectations/tests/template_typedefs.rs
+++ b/bindgen-tests/tests/expectations/tests/template_typedefs.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type foo = ::std::option::Option<unsafe extern "C" fn(arg1: ::std::os::raw::c_int)>;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/templateref_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/templateref_opaque.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct detail_PointerType {
     pub _address: u8,
 }
 pub type detail_PointerType_Type<T> = *mut T;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct UniquePtr {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/templatized-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/templatized-bitfield.rs
@@ -3,7 +3,7 @@
  be, so we cannot allocate bitfield units. The best thing we can do is make
  the struct opaque.*/
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TemplatizedBitfield {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -16,7 +16,7 @@ pub type Char = ::std::os::raw::c_char;
 pub type SChar = ::std::os::raw::c_schar;
 pub type UChar = ::std::os::raw::c_uchar;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Test {
     pub ch: ::std::os::raw::c_char,
     pub u: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -10,7 +10,7 @@ pub type Char = ::std::os::raw::c_char;
 pub type SChar = ::std::os::raw::c_schar;
 pub type UChar = ::std::os::raw::c_uchar;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Test {
     pub ch: ::std::os::raw::c_char,
     pub u: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct timex {
     pub tai: ::std::os::raw::c_int,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
@@ -167,7 +173,7 @@ impl Default for timex {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct timex_named {
     pub tai: ::std::os::raw::c_int,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -43,7 +43,7 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StylePoint<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: T,
@@ -74,7 +74,7 @@ pub const StyleFoo_Tag_Baz: StyleFoo_Tag = 0;
 pub const StyleFoo_Tag_Bazz: StyleFoo_Tag = 0;
 pub type StyleFoo_Tag = u8;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleFoo_Foo_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -92,7 +92,7 @@ impl<T> Default for StyleFoo_Foo_Body<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleFoo_Bar_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -108,7 +108,7 @@ impl<T> Default for StyleFoo_Bar_Body<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleFoo_Baz_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
@@ -124,7 +124,7 @@ impl<T> Default for StyleFoo_Baz_Body<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleFoo__bindgen_ty_1 {
     pub tag: StyleFoo_Tag,
 }
@@ -158,7 +158,7 @@ pub const StyleBar_Tag_Bar3: StyleBar_Tag = 0;
 pub const StyleBar_Tag_Bar4: StyleBar_Tag = 0;
 pub type StyleBar_Tag = ::std::os::raw::c_int;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleBar_StyleBar1_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: i32,
@@ -175,7 +175,7 @@ impl<T> Default for StyleBar_StyleBar1_Body<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleBar_StyleBar2_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _0: T,
@@ -190,7 +190,7 @@ impl<T> Default for StyleBar_StyleBar2_Body<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct StyleBar_StyleBar3_Body<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _0: StylePoint<T>,

--- a/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct dl_phdr_info {
     pub x: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/type_alias_partial_template_especialization.rs
+++ b/bindgen-tests/tests/expectations/tests/type_alias_partial_template_especialization.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub type MaybeWrapped<A> = A;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub ptr: MaybeWrapped<T>,

--- a/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
+++ b/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Rooted {
     pub ptr: MaybeWrapped<::std::os::raw::c_int>,
 }

--- a/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
+++ b/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub inner: ::std::os::raw::c_char,
 }
@@ -12,7 +12,7 @@ const _: () = {
 };
 pub type foo_ptr = *const foo;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct bar {
     pub inner: ::std::os::raw::c_char,
 }
@@ -30,7 +30,7 @@ pub struct baz {
 }
 pub type baz_ptr = *mut baz;
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union cat {
     pub standard_issue: ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/expectations/tests/typeref.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
@@ -17,7 +17,7 @@ const _: () = {
     ][::std::mem::offset_of!(mozilla_FragmentOrURL, mIsLocalRef) - 0usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct mozilla_Position {
     pub _address: u8,
 }
@@ -56,7 +56,7 @@ impl Default for mozilla_StyleShapeSource {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Bar {
     pub mFoo: *mut nsFoo,
 }

--- a/bindgen-tests/tests/expectations/tests/uncallable_functions.rs
+++ b/bindgen-tests/tests/expectations/tests/uncallable_functions.rs
@@ -4,7 +4,7 @@ pub struct Test__bindgen_vtable {
     pub Test_a: unsafe extern "C" fn(this: *mut Test),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Test {
     pub vtable_: *const Test__bindgen_vtable,
 }

--- a/bindgen-tests/tests/expectations/tests/underscore.rs
+++ b/bindgen-tests/tests/expectations/tests/underscore.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const __: ::std::os::raw::c_int = 10;
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct ptr_t {
     pub __: [::std::os::raw::c_uchar; 8usize],
 }

--- a/bindgen-tests/tests/expectations/tests/union-align.rs
+++ b/bindgen-tests/tests/expectations/tests/union-align.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Bar {
     pub foo: ::std::os::raw::c_uchar,
 }
@@ -22,7 +22,7 @@ impl Default for Bar {
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Baz {
     pub bar: Bar,
 }

--- a/bindgen-tests/tests/expectations/tests/union-in-ns.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns.rs
@@ -4,7 +4,7 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Copy, Clone)]
+    #[derive(Clone, Copy)]
     pub union bar {
         pub baz: ::std::os::raw::c_int,
     }

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,12 +145,14 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union U4 {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -206,7 +212,7 @@ impl U4 {
     pub fn new_bitfield_1(
         derp: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -220,7 +226,7 @@ impl U4 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union B {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
@@ -316,7 +322,7 @@ impl B {
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 1usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/union_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union nsStyleUnion {
     pub mInt: ::std::os::raw::c_int,
     pub mFloat: f32,

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,18 +145,20 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo {
     pub a: ::std::os::raw::c_int,
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct foo__bindgen_ty_1 {
     pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -242,7 +248,7 @@ impl foo__bindgen_ty_1 {
         b: ::std::os::raw::c_int,
         c: ::std::os::raw::c_int,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo {
     pub bar: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union pixel {
     pub rgba: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: pixel__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct pixel__bindgen_ty_1 {
     pub r: ::std::os::raw::c_uchar,
     pub g: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo {
     pub a: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1 {
     pub b: ::std::os::raw::c_ushort,
     pub c: ::std::os::raw::c_uchar,

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union WithBigArray {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_int; 33usize],
@@ -26,7 +26,7 @@ impl Default for WithBigArray {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union WithBigArray2 {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_char; 33usize],
@@ -52,7 +52,7 @@ impl Default for WithBigArray2 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union WithBigMember {
     pub a: ::std::os::raw::c_int,
     pub b: WithBigArray,

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
@@ -1,18 +1,18 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo {
     pub a: ::std::os::raw::c_uint,
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct foo__bindgen_ty_1 {
     pub __bindgen_anon_1: foo__bindgen_ty_1__bindgen_ty_1,
     pub __bindgen_anon_2: foo__bindgen_ty_1__bindgen_ty_2,
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1__bindgen_ty_1 {
     pub b1: ::std::os::raw::c_ushort,
     pub b2: ::std::os::raw::c_ushort,
@@ -42,7 +42,7 @@ impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union foo__bindgen_ty_1__bindgen_ty_2 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,

--- a/bindgen-tests/tests/expectations/tests/unknown_attr.rs
+++ b/bindgen-tests/tests/expectations/tests/unknown_attr.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
@@ -9,7 +9,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]
 }
 #[repr(C)]
 #[repr(align(16))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
     pub __bindgen_padding_0: __BindgenOpaqueArray8<[u8; 8usize]>,

--- a/bindgen-tests/tests/expectations/tests/unsorted-items.rs
+++ b/bindgen-tests/tests/expectations/tests/unsorted-items.rs
@@ -7,7 +7,7 @@ unsafe extern "C" {
     pub fn bar(x: number) -> ::std::os::raw::c_int;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Point {
     pub x: number,
     pub y: number,
@@ -20,7 +20,7 @@ const _: () = {
     ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
 };
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Angle {
     pub a: number,
     pub b: number,

--- a/bindgen-tests/tests/expectations/tests/use-core.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core.rs
@@ -2,7 +2,7 @@
 #![cfg(not(target_os = "windows"))]
 extern crate core;
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct foo {
     pub a: ::core::ffi::c_int,
     pub b: ::core::ffi::c_int,
@@ -26,7 +26,7 @@ impl Default for foo {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union _bindgen_ty_1 {
     pub bar: ::core::ffi::c_int,
     pub baz: ::core::ffi::c_long,

--- a/bindgen-tests/tests/expectations/tests/using.rs
+++ b/bindgen-tests/tests/expectations/tests/using.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Point<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: T,

--- a/bindgen-tests/tests/expectations/tests/va_list_aarch64_linux.rs
+++ b/bindgen-tests/tests/expectations/tests/va_list_aarch64_linux.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C, align(8))]
 pub struct __BindgenOpaqueArray8<T>(pub T);
 impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub m_baz: ::std::os::raw::c_int,
 }
@@ -23,7 +23,7 @@ impl Bar {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Baz {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -4,7 +4,7 @@ unsafe extern "C" {
     pub fn foo(fmt: *const ::std::os::raw::c_char, ...);
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Bar {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/variadic_template_function.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic_template_function.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct VariadicFunctionObject {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/vector.rs
+++ b/bindgen-tests/tests/expectations/tests/vector.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct foo {
     pub mMember: [::std::os::raw::c_longlong; 1usize],
 }

--- a/bindgen-tests/tests/expectations/tests/virtual_inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_inheritance.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct A {
     pub foo: ::std::os::raw::c_int,
 }
 #[repr(C)]
 pub struct B__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct B {
     pub vtable_: *const B__bindgen_vtable,
     pub bar: ::std::os::raw::c_int,
@@ -24,7 +24,7 @@ impl Default for B {
 #[repr(C)]
 pub struct C__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub vtable_: *const C__bindgen_vtable,
     pub baz: ::std::os::raw::c_int,
@@ -39,7 +39,7 @@ impl Default for C {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct D {
     pub _base: C,
     pub _base_1: B,

--- a/bindgen-tests/tests/expectations/tests/virtual_interface.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_interface.rs
@@ -8,7 +8,7 @@ pub struct PureVirtualIFace__bindgen_vtable {
     ),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PureVirtualIFace {
     pub vtable_: *const PureVirtualIFace__bindgen_vtable,
 }
@@ -33,7 +33,7 @@ pub struct AnotherInterface__bindgen_vtable {
     pub AnotherInterface_Baz: unsafe extern "C" fn(this: *mut AnotherInterface),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct AnotherInterface {
     pub vtable_: *const AnotherInterface__bindgen_vtable,
 }
@@ -54,7 +54,7 @@ impl Default for AnotherInterface {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Implementation {
     pub _base: PureVirtualIFace,
 }
@@ -73,7 +73,7 @@ impl Default for Implementation {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct DoubleImpl {
     pub _base: PureVirtualIFace,
     pub _base_1: AnotherInterface,

--- a/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
@@ -5,7 +5,7 @@ pub struct C__bindgen_vtable {
     pub C_do_thing1: unsafe extern "C" fn(this: *mut C, arg1: ::std::os::raw::c_int),
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub vtable_: *const C__bindgen_vtable,
 }

--- a/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
@@ -4,7 +4,7 @@ pub struct Base__bindgen_vtable {
     pub Base_AsDerived: unsafe extern "C" fn(this: *mut Base) -> *mut Derived,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Base {
     pub vtable_: *const Base__bindgen_vtable,
 }
@@ -27,7 +27,7 @@ unsafe extern "C" {
     pub fn Base_AsDerived(this: *mut ::std::os::raw::c_void) -> *mut Derived;
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Derived {
     pub _base: Base,
 }

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -1,15 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug)]
 pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
         Self { storage }
     }
 }
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -32,12 +34,12 @@ where
         Self::extract_bit(byte, index)
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>().add(byte_index)
         };
         Self::extract_bit(byte, index)
     }
@@ -59,12 +61,12 @@ where
         *byte = Self::change_bit(*byte, index, val);
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>().add(byte_index)
         };
         unsafe { *byte = Self::change_bit(*byte, index, val) };
     }
@@ -89,6 +91,7 @@ where
         val
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(this: *const Self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -127,6 +130,7 @@ where
         }
     }
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(this: *mut Self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < core::mem::size_of::<Storage>());
@@ -141,7 +145,9 @@ where
             } else {
                 i
             };
-            unsafe { Self::raw_set_bit(this, index + bit_offset, val_bit_is_set) };
+            unsafe {
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
+            };
         }
     }
 }
@@ -153,7 +159,7 @@ pub enum nsStyleSVGOpacitySource {
     eStyleSVGOpacitySource_ContextStrokeOpacity = 2,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct Weird {
     pub mStrokeDasharrayLength: ::std::os::raw::c_uint,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
@@ -299,7 +305,7 @@ impl Weird {
         bitTest: ::std::os::raw::c_uint,
         bitTest2: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 4usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -513,7 +519,7 @@ impl Weird {
         mStrokeDashoffsetFromObject: bool,
         mStrokeWidthFromObject: bool,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        let mut __bindgen_bitfield_unit = __BindgenBitfieldUnit::new([0u8; 2usize]);
         __bindgen_bitfield_unit
             .set(
                 0usize,

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct UnknownUnits {
     pub _address: u8,
 }
@@ -11,7 +11,7 @@ const _: () = {
 };
 pub type Float = f32;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct PointTyped<F> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<F>>,
     pub x: F,

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(not(test))]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![cfg(target = "i686-pc-windows-msvc")]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "nightly")]
 #![feature(abi_thiscall)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Foo {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_class.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_class.rs
@@ -30,7 +30,7 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct C {
     pub a: ::std::os::raw::c_int,
     pub big_array: [::std::os::raw::c_char; 33usize],
@@ -133,7 +133,7 @@ impl Default for IncompleteArrayNonCopiable {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub union Union {
     pub d: f32,
     pub i: ::std::os::raw::c_int,
@@ -148,7 +148,7 @@ impl Default for Union {
     }
 }
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct WithUnion {
     pub data: Union,
 }
@@ -162,7 +162,7 @@ impl Default for WithUnion {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct RealAbstractionWithTonsOfMethods {
     pub _address: u8,
 }

--- a/bindgen-tests/tests/headers/bitfield_comma_separated_derives.h
+++ b/bindgen-tests/tests/headers/bitfield_comma_separated_derives.h
@@ -1,0 +1,14 @@
+// Test that comma-separated derives in rustbindgen annotations are properly split
+
+/** <div rustbindgen derive="PartialEq,Eq"></div> */
+struct first_bitfield_struct {
+    unsigned int a : 1;
+    unsigned int b : 2;
+    unsigned int c : 3;
+};
+
+/** <div rustbindgen derive="Clone, Copy"></div> */
+struct second_bitfield_struct {
+    unsigned int x : 4;
+    unsigned int y : 4;
+};

--- a/bindgen-tests/tests/headers/bitfield_union_derives.h
+++ b/bindgen-tests/tests/headers/bitfield_union_derives.h
@@ -1,0 +1,19 @@
+// Test that __BindgenBitfieldUnit gets the union of derives from all structs using it
+
+/** <div rustbindgen derive="PartialEq"></div> */
+struct first_bitfield_struct {
+    unsigned int a : 1;
+    unsigned int b : 2;
+    unsigned int c : 3;
+};
+
+/** <div rustbindgen derive="PartialEq, Eq"></div> */
+struct second_bitfield_struct {
+    unsigned int x : 4;
+    unsigned int y : 4;
+};
+
+// Third struct with no custom derives but should still work
+struct third_bitfield_struct {
+    unsigned int z : 8;
+};

--- a/bindgen-tests/tests/headers/complex_union_derives.h
+++ b/bindgen-tests/tests/headers/complex_union_derives.h
@@ -1,0 +1,15 @@
+// bindgen-flags: --with-derive-partialeq
+// Test that __BindgenComplex gets the union of derives from all structs using it
+
+struct first_complex_struct {
+    double _Complex a;
+};
+
+struct second_complex_struct {
+    float _Complex b;
+};
+
+// Third struct with no custom derives but should still work
+struct third_complex_struct {
+    double _Complex c;
+};

--- a/bindgen-tests/tests/headers/float16_union_derives.h
+++ b/bindgen-tests/tests/headers/float16_union_derives.h
@@ -1,0 +1,15 @@
+// bindgen-flags: --with-derive-partialeq
+// Test that __BindgenFloat16 gets the union of derives from all structs using it
+
+struct first_float16_struct {
+    __fp16 a;
+};
+
+struct second_float16_struct {
+    __fp16 b;
+};
+
+// Third struct with no custom derives but should still work
+struct third_float16_struct {
+    __fp16 c;
+};

--- a/bindgen-tests/tests/headers/opaque_array_union_derives.h
+++ b/bindgen-tests/tests/headers/opaque_array_union_derives.h
@@ -1,0 +1,19 @@
+// Test that opaque arrays get the union of derives from all structs using them
+
+/** <div rustbindgen derive="PartialEq"></div> */
+struct first_struct {
+    int x;
+    char padding_to_align[60] __attribute__((aligned(64)));
+};
+
+/** <div rustbindgen derive="PartialEq, Eq"></div> */
+struct second_struct {
+    int y;
+    char more_padding[60] __attribute__((aligned(64)));
+};
+
+// Third struct with no custom derives but should still work
+struct third_struct {
+    int z;
+    char final_padding[60] __attribute__((aligned(64)));
+};

--- a/bindgen/codegen/bitfield_unit_impl.rs
+++ b/bindgen/codegen/bitfield_unit_impl.rs
@@ -1,9 +1,10 @@
-#[repr(C)]
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage> {
-    storage: Storage,
-}
+// Implementation for __BindgenBitfieldUnit.
+// The struct definition is generated in mod.rs::prepend_bitfield_unit_type()
+// with #[repr(C)] and custom derives based on the types using it.
 
+// Allow unused qualifications because this file is included via include!() macro
+// in both test and production code, and we need the full paths to be explicit.
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
@@ -11,6 +12,7 @@ impl<Storage> __BindgenBitfieldUnit<Storage> {
     }
 }
 
+#[allow(unused_qualifications)]
 impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
@@ -39,13 +41,14 @@ where
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get_bit(this: *const Self, index: usize) -> bool {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
 
         let byte_index = index / 8;
         let byte = unsafe {
-            *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+            *core::ptr::addr_of!((*this).storage).cast::<u8>()
+                .add(byte_index)
         };
 
         Self::extract_bit(byte, index)
@@ -78,13 +81,14 @@ where
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set_bit(this: *mut Self, index: usize, val: bool) {
         debug_assert!(index / 8 < core::mem::size_of::<Storage>());
 
         let byte_index = index / 8;
         let byte = unsafe {
-            (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+            core::ptr::addr_of_mut!((*this).storage).cast::<u8>()
+                .add(byte_index)
         };
 
         unsafe { *byte = Self::change_bit(*byte, index, val) };
@@ -116,6 +120,7 @@ where
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_get(
         this: *const Self,
         bit_offset: usize,
@@ -166,6 +171,7 @@ where
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub unsafe fn raw_set(
         this: *mut Self,
         bit_offset: usize,
@@ -188,7 +194,7 @@ where
                 i
             };
             unsafe {
-                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set)
+                Self::raw_set_bit(this, index + bit_offset, val_bit_is_set);
             };
         }
     }

--- a/bindgen/codegen/bitfield_unit_tests.rs
+++ b/bindgen/codegen/bitfield_unit_tests.rs
@@ -21,7 +21,15 @@
 //! +------------------------------------------------------------+
 //! ```
 
-use super::bitfield_unit::__BindgenBitfieldUnit;
+// For testing purposes, define __BindgenBitfieldUnit with standard derives.
+// In production code, this is generated in prepend_bitfield_unit_type() with custom derives.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+
+include!("bitfield_unit_impl.rs");
 
 #[test]
 fn bitfield_unit_get_bit() {

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -229,7 +229,15 @@ impl Annotations {
                             attr.value.split("::").map(Into::into).collect(),
                         );
                     }
-                    "derive" => self.derives.push(attr.value),
+                    "derive" => {
+                        // Split comma-separated derives into individual entries
+                        for derive in attr.value.split(',') {
+                            let derive = derive.trim();
+                            if !derive.is_empty() {
+                                self.derives.push(derive.to_string());
+                            }
+                        }
+                    }
                     "attribute" => self.attributes.push(attr.value),
                     "private" => {
                         self.visibility_kind = if attr.value == "false" {


### PR DESCRIPTION
Rather than deriving a fixed set of traits for _BindgenOpaqueArray and similar wrapper types, derive the same traits that the types using them need. This avoids deriving unused traits, and also supports custom traits.