### PR TITLE
refactor: centralize comment generation checks

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1619,11 +1619,8 @@ impl FieldCodegen<'_> for FieldData {
         };
 
         let mut field = quote! {};
-        if ctx.options().generate_comments {
-            if let Some(raw_comment) = self.comment() {
-                let comment = ctx.options().process_comment(raw_comment);
-                field = attributes::doc(&comment);
-            }
+        if let Some(comment) = self.doc_comment(ctx) {
+            field = attributes::doc(&comment);
         }
 
         let field_name = self
@@ -3933,14 +3930,11 @@ impl CodeGenerator for Enum {
                 continue;
             }
 
-            let mut variant_doc = quote! {};
-            if ctx.options().generate_comments {
-                if let Some(raw_comment) = variant.comment() {
-                    let processed_comment =
-                        ctx.options().process_comment(raw_comment);
-                    variant_doc = attributes::doc(&processed_comment);
-                }
-            }
+            let variant_doc = if let Some(comment) = variant.doc_comment(ctx) {
+                attributes::doc(&comment)
+            } else {
+                quote! {}
+            };
 
             match seen_values.entry(variant.val()) {
                 Entry::Occupied(ref entry) => {

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -142,6 +142,7 @@ pub(crate) trait FieldMethods {
     fn ty(&self) -> TypeId;
 
     /// Get the comment for this field.
+    #[allow(dead_code)] // Used by trait implementations in Field wrapper types
     fn comment(&self) -> Option<&str>;
 
     /// If this is a bitfield, how many bits does it need?
@@ -899,6 +900,20 @@ impl FieldMethods for FieldData {
 
     fn offset(&self) -> Option<usize> {
         self.offset
+    }
+}
+
+impl FieldData {
+    /// Get this field's documentation comment, if it has any, already preprocessed
+    /// and with the right indentation. Returns `None` if comment generation is disabled.
+    pub(crate) fn doc_comment(&self, ctx: &BindgenContext) -> Option<String> {
+        if !ctx.options().generate_comments {
+            return None;
+        }
+
+        self.comment
+            .as_ref()
+            .map(|comment| ctx.options().process_comment(comment))
     }
 }
 

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -302,9 +302,16 @@ impl EnumVariant {
         self.val
     }
 
-    /// Get this variant's documentation.
-    pub(crate) fn comment(&self) -> Option<&str> {
-        self.comment.as_deref()
+    /// Get this variant's documentation comment, if it has any, already preprocessed
+    /// and with the right indentation. Returns `None` if comment generation is disabled.
+    pub(crate) fn doc_comment(&self, ctx: &BindgenContext) -> Option<String> {
+        if !ctx.options().generate_comments {
+            return None;
+        }
+
+        self.comment
+            .as_ref()
+            .map(|comment| ctx.options().process_comment(comment))
     }
 
     /// Returns whether this variant should be enforced to be a constant by code


### PR DESCRIPTION
hi, this my first pr which refactor. eliminates duplicate `generate_comments` checks from codegen. types now handle check themselves, centralized decision logic per type, cleaner code. `FieldData::doc_comment()` and `EnumVariant::doc_comment()` make it idiomatic.

Hope receive feedback

fixes #445