### PR TITLE
fix: support header_contents() with clang_macro_fallback

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -825,6 +825,52 @@ fn test_macro_fallback_header_contents_parent_dir_escape() {
 }
 
 #[test]
+fn test_macro_fallback_cross_target() {
+    // Subprocess-style test: setting TARGET as an env var in a parallel
+    // test is not robust, so we re-invoke the test binary as a child
+    // process with TARGET set to a non-host triple. The child runs the
+    // actual assertion; the parent just checks the exit status.
+    //
+    // __SIZEOF_POINTER__ is a clang builtin that equals the target's
+    // pointer width. On armv7 it's 4; on x86_64 it's 8. If the
+    // implicit --target isn't propagated to fallback_clang_args, the
+    // fallback TU evaluates with the host pointer size instead.
+    if env::var("__BINDGEN_CROSS_TARGET_INNER").is_ok() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let actual = builder()
+            .disable_header_comment()
+            .header_contents("test.h", "#define PTR_BYTES __SIZEOF_POINTER__\n")
+            .clang_macro_fallback()
+            .clang_macro_fallback_build_dir(tmpdir.path())
+            .generate()
+            .unwrap()
+            .to_string();
+        assert!(
+            actual.contains("pub const PTR_BYTES: u32 = 4;"),
+            "Expected 4-byte pointers for armv7 target, got:\n{actual}"
+        );
+        return;
+    }
+
+    let exe = env::current_exe().unwrap();
+    let output = std::process::Command::new(&exe)
+        .arg("test_macro_fallback_cross_target")
+        .arg("--exact")
+        .arg("--test-threads=1")
+        .env("TARGET", "armv7-unknown-linux-gnueabihf")
+        .env("__BINDGEN_CROSS_TARGET_INNER", "1")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Cross-target fallback test failed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 // Doesn't support executing sh file on Windows.
 // We may want to implement it in Rust so that we support all systems.
 #[cfg(not(target_os = "windows"))]

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -617,8 +617,19 @@ fn test_macro_fallback_non_system_dir() {
     }
 }
 
+/// clang 9's `clang_Cursor_Evaluate` returns `CXEval_UnExposed` instead
+/// of `CXEval_Int` for macro-expanded expressions loaded through a PCH
+/// built from materialized `header_contents()` files, so fallback
+/// constant evaluation produces no results in that specific path.
+fn clang9_fallback_header_contents_works() -> bool {
+    !matches!(clang_version().parsed, Some((9, _)))
+}
+
 #[test]
 fn test_macro_fallback_header_contents() {
+    if !clang9_fallback_header_contents_works() {
+        return;
+    }
     let tmpdir = tempfile::tempdir().unwrap();
     let actual = builder()
         .disable_header_comment()
@@ -647,6 +658,9 @@ fn test_macro_fallback_header_contents() {
 
 #[test]
 fn test_macro_fallback_multiple_header_contents() {
+    if !clang9_fallback_header_contents_works() {
+        return;
+    }
     let tmpdir = tempfile::tempdir().unwrap();
     let actual = builder()
         .disable_header_comment()
@@ -675,6 +689,9 @@ fn test_macro_fallback_multiple_header_contents() {
 
 #[test]
 fn test_macro_fallback_mixed_header_and_header_contents() {
+    if !clang9_fallback_header_contents_works() {
+        return;
+    }
     let tmpdir = tempfile::tempdir().unwrap();
     let actual = builder()
         .disable_header_comment()
@@ -709,6 +726,9 @@ fn test_macro_fallback_mixed_header_and_header_contents() {
 
 #[test]
 fn test_macro_fallback_header_contents_duplicate_basename() {
+    if !clang9_fallback_header_contents_works() {
+        return;
+    }
     let tmpdir = tempfile::tempdir().unwrap();
     let actual = builder()
         .disable_header_comment()
@@ -768,11 +788,13 @@ fn test_macro_fallback_header_contents_absolute_name() {
         .unwrap()
         .to_string();
 
-    // The fallback-only constant should be evaluated.
-    assert!(
-        actual.contains("pub const ABS_CONST: u32 = 55;"),
-        "Expected ABS_CONST in output:\n{actual}"
-    );
+    // The fallback-only constant should be evaluated (not on clang 9).
+    if clang9_fallback_header_contents_works() {
+        assert!(
+            actual.contains("pub const ABS_CONST: u32 = 55;"),
+            "Expected ABS_CONST in output:\n{actual}"
+        );
+    }
 
     // The original file must not have been deleted by FallbackTU drop.
     assert!(
@@ -811,10 +833,12 @@ fn test_macro_fallback_header_contents_parent_dir_escape() {
         .unwrap()
         .to_string();
 
-    assert!(
-        actual.contains("pub const ESCAPE_CONST: u32 = 77;"),
-        "Expected ESCAPE_CONST in output:\n{actual}"
-    );
+    if clang9_fallback_header_contents_works() {
+        assert!(
+            actual.contains("pub const ESCAPE_CONST: u32 = 77;"),
+            "Expected ESCAPE_CONST in output:\n{actual}"
+        );
+    }
 
     // The file outside build_dir must not have been clobbered.
     assert!(
@@ -826,6 +850,9 @@ fn test_macro_fallback_header_contents_parent_dir_escape() {
 
 #[test]
 fn test_macro_fallback_cross_target() {
+    if !clang9_fallback_header_contents_works() {
+        return;
+    }
     // Subprocess-style test: setting TARGET as an env var in a parallel
     // test is not robust, so we re-invoke the test binary as a child
     // process with TARGET set to a non-host triple. The child runs the

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -618,6 +618,213 @@ fn test_macro_fallback_non_system_dir() {
 }
 
 #[test]
+fn test_macro_fallback_header_contents() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            "test.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define SIMPLE 42\n\
+             #define COMPOUND UINT32_C(69)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+
+    let expected = format_code(
+        "pub const SIMPLE: u32 = 42;\npub const COMPOUND: u32 = 69;\n",
+    )
+    .unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_macro_fallback_multiple_header_contents() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents("defs.h", "#define UINT32_C(c) c ## U\n")
+        .header_contents(
+            "test.h",
+            "#include \"defs.h\"\n\
+             #define MY_CONST UINT32_C(28)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+
+    // UINT32_C is a function-like macro, should not appear as a constant.
+    // MY_CONST should be evaluated by the fallback.
+    assert!(
+        actual.contains("pub const MY_CONST: u32 = 28;"),
+        "Expected MY_CONST constant in output:\n{actual}"
+    );
+}
+
+#[test]
+fn test_macro_fallback_mixed_header_and_header_contents() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let actual = builder()
+        .disable_header_comment()
+        .header(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/headers/issue-753.h"
+        ))
+        .header_contents(
+            "extra.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define EXTRA_CONST UINT32_C(99)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+
+    // Constants from the real header (issue-753.h defines UINT32_C and uses it)
+    assert!(
+        actual.contains("pub const CONST: u32 = 5;"),
+        "Expected CONST from real header in output:\n{actual}"
+    );
+    // Constants from the virtual header via fallback
+    assert!(
+        actual.contains("pub const EXTRA_CONST: u32 = 99;"),
+        "Expected EXTRA_CONST from header_contents in output:\n{actual}"
+    );
+}
+
+#[test]
+fn test_macro_fallback_header_contents_duplicate_basename() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            "defs.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define FROM_ROOT UINT32_C(11)\n",
+        )
+        .header_contents(
+            "sub/defs.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define FROM_SUB UINT32_C(22)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+
+    assert!(
+        actual.contains("pub const FROM_ROOT: u32 = 11;"),
+        "Expected FROM_ROOT in output:\n{actual}"
+    );
+    assert!(
+        actual.contains("pub const FROM_SUB: u32 = 22;"),
+        "Expected FROM_SUB in output:\n{actual}"
+    );
+}
+
+#[test]
+fn test_macro_fallback_header_contents_absolute_name() {
+    // Absolute names must not escape the build dir — they should be
+    // materialized safely under it, and the original file must not be
+    // clobbered or deleted.
+    let tmpdir = tempfile::tempdir().unwrap();
+    let victim = tmpdir.path().join("victim.h");
+    fs::write(&victim, "// original content\n").unwrap();
+
+    let abs_name = victim.to_str().unwrap();
+    let build_dir = tmpdir.path().join("fallback_build");
+    fs::create_dir_all(&build_dir).unwrap();
+
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            abs_name,
+            "#define UINT32_C(c) c ## U\n\
+             #define ABS_CONST UINT32_C(55)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(&build_dir)
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    // The fallback-only constant should be evaluated.
+    assert!(
+        actual.contains("pub const ABS_CONST: u32 = 55;"),
+        "Expected ABS_CONST in output:\n{actual}"
+    );
+
+    // The original file must not have been deleted by FallbackTU drop.
+    assert!(
+        victim.exists(),
+        "Original file at {abs_name} was deleted by fallback cleanup"
+    );
+    assert_eq!(
+        fs::read_to_string(&victim).unwrap(),
+        "// original content\n",
+        "Original file at {abs_name} was overwritten by materialization"
+    );
+}
+
+#[test]
+fn test_macro_fallback_header_contents_parent_dir_escape() {
+    // Names with ".." must not escape the build dir or delete files
+    // outside it during FallbackTranslationUnit cleanup.
+    let tmpdir = tempfile::tempdir().unwrap();
+    let victim = tmpdir.path().join("victim.h");
+    fs::write(&victim, "// must survive\n").unwrap();
+
+    let build_dir = tmpdir.path().join("build");
+    fs::create_dir_all(&build_dir).unwrap();
+
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            "../victim.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define ESCAPE_CONST UINT32_C(77)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(&build_dir)
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    assert!(
+        actual.contains("pub const ESCAPE_CONST: u32 = 77;"),
+        "Expected ESCAPE_CONST in output:\n{actual}"
+    );
+
+    // The file outside build_dir must not have been clobbered.
+    assert!(
+        victim.exists(),
+        "File outside build dir was deleted by fallback cleanup"
+    );
+    assert_eq!(fs::read_to_string(&victim).unwrap(), "// must survive\n",);
+}
+
+#[test]
 // Doesn't support executing sh file on Windows.
 // We may want to implement it in Rust so that we support all systems.
 #[cfg(not(target_os = "windows"))]

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -618,6 +618,186 @@ fn test_macro_fallback_non_system_dir() {
 }
 
 #[test]
+fn test_macro_fallback_header_contents() {
+    if let Some((9, _)) = clang_version().parsed {
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            "test.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define SIMPLE 42\n\
+             #define COMPOUND UINT32_C(69)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+    let expected = format_code(
+        "pub const SIMPLE: u32 = 42;\npub const COMPOUND: u32 = 69;\n",
+    )
+    .unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_macro_fallback_header_contents_preserves_build_dir_files() {
+    if let Some((9, _)) = clang_version().parsed {
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let victim = tmpdir.path().join(".macro_eval_header_0.h");
+    fs::write(&victim, "must survive\n").unwrap();
+
+    let actual = builder()
+        .disable_header_comment()
+        .header_contents(
+            "test.h",
+            "#define UINT32_C(c) c ## U\n\
+             #define COMPOUND UINT32_C(69)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+    let expected = format_code("pub const COMPOUND: u32 = 69;\n").unwrap();
+
+    assert_eq!(expected, actual);
+    assert_eq!("must survive\n", fs::read_to_string(victim).unwrap());
+}
+
+#[test]
+fn test_macro_fallback_header_contents_preserves_primary_header_order() {
+    if let Some((9, _)) = clang_version().parsed {
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let header = tmpdir.path().join("primary.h");
+    fs::write(
+        &header,
+        "#undef ORDER_VALUE\n#define ORDER_VALUE UINT32_C(1)\n",
+    )
+    .unwrap();
+
+    let actual = builder()
+        .disable_header_comment()
+        .header(header.to_str().unwrap())
+        .header_contents(
+            "override.h",
+            "#define UINT32_C(c) c ## U\n\
+             #undef ORDER_VALUE\n\
+             #define ORDER_VALUE UINT32_C(2)\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+    let expected = format_code("pub const ORDER_VALUE: u32 = 1;\n").unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_macro_fallback_header_contents_preserves_include_identity() {
+    if let Some((9, _)) = clang_version().parsed {
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let header = tmpdir.path().join("primary.h");
+    fs::write(
+        &header,
+        "#undef BINDGEN_VIRTUAL_FUNC_3353\n\
+         #include \"bindgen_virtual_dependency_3353.h\"\n\
+         #define FROM_INCLUDE BINDGEN_VIRTUAL_FUNC_3353(7)\n",
+    )
+    .unwrap();
+    let virtual_dir = tmpdir.path().join("virtual");
+    fs::create_dir(&virtual_dir).unwrap();
+    let virtual_header = virtual_dir.join("bindgen_virtual_dependency_3353.h");
+
+    let actual = builder()
+        .disable_header_comment()
+        .header(header.to_str().unwrap())
+        .header_contents(
+            virtual_header.to_str().unwrap(),
+            "#define BINDGEN_VIRTUAL_FUNC_3353(c) c ## U\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg(format!("-I{}", virtual_dir.display()))
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+    let expected = format_code("pub const FROM_INCLUDE: u32 = 7;\n").unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn test_macro_fallback_header_contents_preserves_full_include_identity() {
+    if let Some((9, _)) = clang_version().parsed {
+        return;
+    }
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let header = tmpdir.path().join("primary.h");
+    fs::write(&header, "#define FROM_COMMON COMMON_MACRO(9)\n").unwrap();
+
+    let virtual_dir = tmpdir.path().join("virtual");
+    let a_dir = virtual_dir.join("a");
+    let b_dir = virtual_dir.join("b");
+    fs::create_dir_all(&a_dir).unwrap();
+    fs::create_dir_all(&b_dir).unwrap();
+    let a_header = a_dir.join("common.h");
+    let b_header = b_dir.join("common.h");
+
+    let actual = builder()
+        .disable_header_comment()
+        .header(header.to_str().unwrap())
+        .header_contents(
+            a_header.to_str().unwrap(),
+            "#define COMMON_MACRO(c) 0\n",
+        )
+        .header_contents(
+            b_header.to_str().unwrap(),
+            "#undef COMMON_MACRO\n#define COMMON_MACRO(c) c ## U\n",
+        )
+        .clang_macro_fallback()
+        .clang_macro_fallback_build_dir(tmpdir.path())
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let actual = format_code(actual).unwrap();
+    let expected = format_code("pub const FROM_COMMON: u32 = 9;\n").unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 // Doesn't support executing sh file on Windows.
 // We may want to implement it in Rust so that we support all systems.
 #[cfg(not(target_os = "windows"))]

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1915,6 +1915,9 @@ impl Drop for TranslationUnit {
 pub(crate) struct FallbackTranslationUnit {
     file_path: String,
     pch_path: String,
+    /// Header files materialized from `header_contents()` that must remain on
+    /// disk while the PCH is in use (clang validates source file existence).
+    materialized_headers: Vec<String>,
     idx: Box<Index>,
     tu: TranslationUnit,
 }
@@ -1931,6 +1934,7 @@ impl FallbackTranslationUnit {
         file: String,
         pch_path: String,
         c_args: &[Box<str>],
+        materialized_headers: Vec<String>,
     ) -> Option<Self> {
         // Create empty file
         OpenOptions::new()
@@ -1951,6 +1955,7 @@ impl FallbackTranslationUnit {
         Some(FallbackTranslationUnit {
             file_path: file,
             pch_path,
+            materialized_headers,
             tu: f_translation_unit,
             idx: f_index,
         })
@@ -1989,6 +1994,9 @@ impl Drop for FallbackTranslationUnit {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.file_path);
         let _ = std::fs::remove_file(&self.pch_path);
+        for path in &self.materialized_headers {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }
 

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -14,8 +14,13 @@ use std::fs::OpenOptions;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::os::raw::{c_char, c_int, c_longlong, c_uint, c_ulong, c_ulonglong};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
 use std::{mem, ptr, slice};
+
+/// Counter used to create collision-free macro fallback scratch directories.
+static NEXT_FALLBACK_ARTIFACT_DIR: AtomicUsize = AtomicUsize::new(0);
 
 /// Type representing a clang attribute.
 ///
@@ -1911,12 +1916,61 @@ impl Drop for TranslationUnit {
     }
 }
 
-/// Translation unit used for macro fallback parsing
-pub(crate) struct FallbackTranslationUnit {
+/// Scratch files used by macro fallback parsing.
+pub(crate) struct FallbackArtifacts {
     file_path: String,
     pch_path: String,
+    dir_path: String,
+}
+
+impl FallbackArtifacts {
+    /// Create a private artifact directory under `build_dir`.
+    pub(crate) fn new(build_dir: &str) -> Option<Self> {
+        let process_id = std::process::id();
+        let dir = loop {
+            let dir_index =
+                NEXT_FALLBACK_ARTIFACT_DIR.fetch_add(1, Ordering::Relaxed);
+            let path = Path::new(build_dir)
+                .join(format!(".macro_eval_{process_id}_{dir_index}"));
+            match std::fs::create_dir(&path) {
+                Ok(()) => break path,
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(_) => return None,
+            }
+        };
+        let dir_path = dir.to_str()?.to_owned();
+        Some(FallbackArtifacts {
+            file_path: format!("{dir_path}/.macro_eval.c"),
+            pch_path: format!("{dir_path}/.macro_eval-precompile.h.pch"),
+            dir_path,
+        })
+    }
+
+    /// Path to the C file used for fallback macro parsing.
+    pub(crate) fn file_path(&self) -> &str {
+        &self.file_path
+    }
+
+    /// Path to the precompiled header used for fallback macro parsing.
+    pub(crate) fn pch_path(&self) -> &str {
+        &self.pch_path
+    }
+}
+
+impl Drop for FallbackArtifacts {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.file_path);
+        let _ = std::fs::remove_file(&self.pch_path);
+        let _ = std::fs::remove_dir(&self.dir_path);
+    }
+}
+
+/// Translation unit used for macro fallback parsing.
+pub(crate) struct FallbackTranslationUnit {
     idx: Box<Index>,
     tu: TranslationUnit,
+    artifacts: FallbackArtifacts,
 }
 
 impl fmt::Debug for FallbackTranslationUnit {
@@ -1928,8 +1982,7 @@ impl fmt::Debug for FallbackTranslationUnit {
 impl FallbackTranslationUnit {
     /// Create a new fallback translation unit
     pub(crate) fn new(
-        file: String,
-        pch_path: String,
+        artifacts: FallbackArtifacts,
         c_args: &[Box<str>],
     ) -> Option<Self> {
         // Create empty file
@@ -1937,22 +1990,21 @@ impl FallbackTranslationUnit {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&file)
+            .open(artifacts.file_path())
             .ok()?;
 
         let f_index = Box::new(Index::new(true, false));
         let f_translation_unit = TranslationUnit::parse(
             &f_index,
-            &file,
+            artifacts.file_path(),
             c_args,
             &[],
             CXTranslationUnit_None,
         )?;
         Some(FallbackTranslationUnit {
-            file_path: file,
-            pch_path,
             tu: f_translation_unit,
             idx: f_index,
+            artifacts,
         })
     }
 
@@ -1966,7 +2018,10 @@ impl FallbackTranslationUnit {
         &mut self,
         unsaved_contents: &str,
     ) -> Result<(), CXErrorCode> {
-        let unsaved = &[UnsavedFile::new(&self.file_path, unsaved_contents)];
+        let unsaved = &[UnsavedFile::new(
+            self.artifacts.file_path(),
+            unsaved_contents,
+        )];
         let mut c_unsaved: Vec<CXUnsavedFile> =
             unsaved.iter().map(|f| f.x).collect();
         let ret = unsafe {
@@ -1982,13 +2037,6 @@ impl FallbackTranslationUnit {
         } else {
             Ok(())
         }
-    }
-}
-
-impl Drop for FallbackTranslationUnit {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.file_path);
-        let _ = std::fs::remove_file(&self.pch_path);
     }
 }
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -5364,7 +5364,8 @@ pub(crate) mod utils {
         }
 
         if !context.options().input_header_contents.is_empty() {
-            for (name, contents) in &context.options().input_header_contents {
+            for (name, contents, _) in &context.options().input_header_contents
+            {
                 writeln!(code, "// {name}\n{contents}")?;
             }
 

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2042,24 +2042,76 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         &mut self,
     ) -> Option<&mut clang::FallbackTranslationUnit> {
         if self.fallback_tu.is_none() {
-            let file = format!(
-                "{}/.macro_eval.c",
+            let build_dir: String =
                 match self.options().clang_macro_fallback_build_dir {
-                    Some(ref path) => path.as_os_str().to_str()?,
-                    None => ".",
-                }
-            );
+                    Some(ref path) => path.as_os_str().to_str()?.to_owned(),
+                    None => ".".to_owned(),
+                };
+            let file = format!("{build_dir}/.macro_eval.c");
 
             let index = clang::Index::new(false, false);
+
+            // Materialize input_header_contents to disk for the fallback
+            // translation unit. header_contents() provides virtual files
+            // that only exist as unsaved buffers in the main TU — the
+            // fallback TU needs real files on disk for PCH compilation.
+            // The files must remain on disk while the PCH is in use
+            // (clang validates source file existence when loading a PCH).
+            //
+            // Both input_headers and input_header_contents are included
+            // so the PCH captures macro definitions from all sources.
+            let materialized_paths: Vec<String> = self
+                .options()
+                .input_header_contents
+                .iter()
+                .filter_map(|(_, contents, original_name)| {
+                    // Sanitize the user-provided name so it always
+                    // resolves under build_dir:
+                    //  - Root/prefix components are dropped (absolute
+                    //    paths can't bypass build_dir via Path::join).
+                    //  - ".." is resolved against the accumulated path
+                    //    but clamped to empty (can't escape build_dir).
+                    //  - "." is skipped.
+                    // This preserves directory structure for collision
+                    // avoidance (e.g. "a.h" vs "dir/a.h") while
+                    // preventing any path from escaping build_dir.
+                    use std::path::Component;
+                    let mut parts: Vec<&std::ffi::OsStr> = Vec::new();
+                    for c in Path::new(original_name.as_ref()).components() {
+                        match c {
+                            Component::Normal(s) => parts.push(s),
+                            Component::ParentDir => {
+                                parts.pop();
+                            }
+                            _ => {}
+                        }
+                    }
+                    let relative: std::path::PathBuf = parts.iter().collect();
+                    let disk_path = Path::new(&build_dir).join(&relative);
+                    if let Some(parent) = disk_path.parent() {
+                        std::fs::create_dir_all(parent).ok()?;
+                    }
+                    std::fs::write(&disk_path, contents.as_ref()).ok()?;
+                    Some(disk_path.to_str()?.to_owned())
+                })
+                .collect();
+
+            let effective_headers: Vec<Box<str>> = self
+                .options()
+                .input_headers
+                .iter()
+                .cloned()
+                .chain(materialized_paths.iter().map(|p| p.clone().into()))
+                .collect();
+
+            let [input_headers @ .., single_header] = &effective_headers[..]
+            else {
+                return None;
+            };
 
             let mut header_names_to_compile = Vec::new();
             let mut header_paths = Vec::new();
             let mut header_includes = Vec::new();
-            let [input_headers @ .., single_header] =
-                &self.options().input_headers[..]
-            else {
-                return None;
-            };
             for input_header in input_headers {
                 let path = Path::new(input_header.as_ref());
                 if let Some(header_path) = path.parent() {
@@ -2071,17 +2123,15 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 } else {
                     header_paths.push(".");
                 }
+                // Use full path for -include to avoid basename
+                // collisions between headers in different directories.
+                header_includes.push(input_header.as_ref().to_string());
                 let header_name = path.file_name()?.to_str()?;
-                header_includes.push(header_name.to_string());
                 header_names_to_compile
                     .push(header_name.split(".h").next()?.to_string());
             }
             let pch = format!(
-                "{}/{}",
-                match self.options().clang_macro_fallback_build_dir {
-                    Some(ref path) => path.as_os_str().to_str()?,
-                    None => ".",
-                },
+                "{build_dir}/{}",
                 header_names_to_compile.join("-") + "-precompile.h.pch"
             );
 
@@ -2118,8 +2168,12 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     c_args.push(arg.clone());
                 }
             }
-            self.fallback_tu =
-                Some(clang::FallbackTranslationUnit::new(file, pch, &c_args)?);
+            self.fallback_tu = Some(clang::FallbackTranslationUnit::new(
+                file,
+                pch,
+                &c_args,
+                materialized_paths,
+            )?);
         }
 
         self.fallback_tu.as_mut()

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2045,26 +2045,55 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         &mut self,
     ) -> Option<&mut clang::FallbackTranslationUnit> {
         if self.fallback_tu.is_none() {
-            let file = format!(
-                "{}/.macro_eval.c",
-                match self.options().clang_macro_fallback_build_dir {
-                    Some(ref path) => path.as_os_str().to_str()?,
-                    None => ".",
-                }
-            );
+            let build_dir = match self.options().clang_macro_fallback_build_dir
+            {
+                Some(ref path) => path.as_os_str().to_str()?.to_owned(),
+                None => ".".to_owned(),
+            };
+            let artifacts = clang::FallbackArtifacts::new(&build_dir)?;
 
             let index = clang::Index::new(false, false);
 
-            let mut header_names_to_compile = Vec::new();
+            let input_unsaved_files = self
+                .options()
+                .input_header_contents
+                .iter()
+                .map(|(name, contents)| {
+                    clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
+                })
+                .collect::<Vec<_>>();
+
+            let mut effective_headers = Vec::new();
+            if self.options().input_headers.is_empty() {
+                if let Some(((single_header, _), input_headers)) =
+                    self.options().input_header_contents.split_first()
+                {
+                    effective_headers.extend(
+                        input_headers.iter().map(|(path, _)| path.as_ref()),
+                    );
+                    effective_headers.push(single_header.as_ref());
+                }
+            } else {
+                let (single_header, input_headers) =
+                    self.options().input_headers.split_last()?;
+                effective_headers
+                    .extend(input_headers.iter().map(|path| path.as_ref()));
+                effective_headers.extend(
+                    self.options()
+                        .input_header_contents
+                        .iter()
+                        .map(|(path, _)| path.as_ref()),
+                );
+                effective_headers.push(single_header.as_ref());
+            }
+
             let mut header_paths = Vec::new();
-            let mut header_includes = Vec::new();
-            let [input_headers @ .., single_header] =
-                &self.options().input_headers[..]
+            let [input_headers @ .., single_header] = &effective_headers[..]
             else {
                 return None;
             };
             for input_header in input_headers {
-                let path = Path::new(input_header.as_ref());
+                let path = Path::new(*input_header);
                 if let Some(header_path) = path.parent() {
                     if header_path == Path::new("") {
                         header_paths.push(".");
@@ -2074,19 +2103,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 } else {
                     header_paths.push(".");
                 }
-                let header_name = path.file_name()?.to_str()?;
-                header_includes.push(header_name.to_string());
-                header_names_to_compile
-                    .push(header_name.split(".h").next()?.to_string());
             }
-            let pch = format!(
-                "{}/{}",
-                match self.options().clang_macro_fallback_build_dir {
-                    Some(ref path) => path.as_os_str().to_str()?,
-                    None => ".",
-                },
-                header_names_to_compile.join("-") + "-precompile.h.pch"
-            );
 
             let mut c_args = self.options.fallback_clang_args.clone();
             c_args.push("-x".to_string().into_boxed_str());
@@ -2094,22 +2111,22 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             for header_path in header_paths {
                 c_args.push(format!("-I{header_path}").into_boxed_str());
             }
-            for header_include in header_includes {
+            for header_include in input_headers {
                 c_args.push("-include".to_string().into_boxed_str());
-                c_args.push(header_include.into_boxed_str());
+                c_args.push((*header_include).into());
             }
             let mut tu = clang::TranslationUnit::parse(
                 &index,
                 single_header,
                 &c_args,
-                &[],
+                &input_unsaved_files,
                 clang_sys::CXTranslationUnit_ForSerialization,
             )?;
-            tu.save(&pch).ok()?;
+            tu.save(artifacts.pch_path()).ok()?;
 
             let mut c_args = vec![
                 "-include-pch".to_string().into_boxed_str(),
-                pch.clone().into_boxed_str(),
+                artifacts.pch_path().to_string().into_boxed_str(),
             ];
             let mut skip_next = false;
             for arg in &self.options.fallback_clang_args {
@@ -2121,8 +2138,9 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     c_args.push(arg.clone());
                 }
             }
-            self.fallback_tu =
-                Some(clang::FallbackTranslationUnit::new(file, pch, &c_args)?);
+            let fallback_tu =
+                clang::FallbackTranslationUnit::new(artifacts, &c_args)?;
+            self.fallback_tu = Some(fallback_tu);
         }
 
         self.fallback_tu.as_mut()

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -787,10 +787,10 @@ impl Bindings {
         // opening libclang.so, it has to be the same architecture and thus the
         // check is fine.
         if !explicit_target && !is_host_build {
-            options.clang_args.insert(
-                0,
-                format!("--target={effective_target}").into_boxed_str(),
-            );
+            let target_arg =
+                format!("--target={effective_target}").into_boxed_str();
+            options.clang_args.insert(0, target_arg.clone());
+            options.fallback_clang_args.insert(0, target_arg);
         }
 
         fn detect_include_paths(options: &mut BindgenOptions) {

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -361,13 +361,14 @@ impl Builder {
                 .flat_map(|header| ["-include".into(), header.clone()]),
         );
 
-        let input_unsaved_files =
-            std::mem::take(&mut self.options.input_header_contents)
-                .into_iter()
-                .map(|(name, contents)| {
-                    clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
-                })
-                .collect::<Vec<_>>();
+        let input_unsaved_files = self
+            .options
+            .input_header_contents
+            .iter()
+            .map(|(name, contents, _)| {
+                clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
+            })
+            .collect::<Vec<_>>();
 
         Bindings::generate(self.options, &input_unsaved_files)
     }
@@ -404,7 +405,7 @@ impl Builder {
 
         // For each input header content, add a prefix line of `#line 0 "$name"`
         // followed by the contents.
-        for (name, contents) in &self.options.input_header_contents {
+        for (name, contents, _) in &self.options.input_header_contents {
             is_cpp |= file_is_cpp(name);
 
             wrapper_contents.push_str("#line 0 \"");

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -361,13 +361,14 @@ impl Builder {
                 .flat_map(|header| ["-include".into(), header.clone()]),
         );
 
-        let input_unsaved_files =
-            std::mem::take(&mut self.options.input_header_contents)
-                .into_iter()
-                .map(|(name, contents)| {
-                    clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
-                })
-                .collect::<Vec<_>>();
+        let input_unsaved_files = self
+            .options
+            .input_header_contents
+            .iter()
+            .map(|(name, contents)| {
+                clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
+            })
+            .collect::<Vec<_>>();
 
         Bindings::generate(self.options, &input_unsaved_files)
     }

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1302,8 +1302,8 @@ options! {
         methods: {},
         as_args: ignore,
     },
-    /// Tuples of unsaved file contents of the form (name, contents).
-    input_header_contents: Vec<(Box<str>, Box<str>)> {
+    /// Tuples of unsaved file contents of the form (absolute name, contents, original name).
+    input_header_contents: Vec<(Box<str>, Box<str>, Box<str>)> {
         methods: {
             /// Add `contents` as an input C/C++ header named `name`.
             ///
@@ -1320,7 +1320,7 @@ options! {
                     .into();
                 self.options
                     .input_header_contents
-                    .push((absolute_path, contents.into()));
+                    .push((absolute_path, contents.into(), name.into()));
                 self
             }
         },

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -2261,13 +2261,12 @@ options! {
     /// headers.
     clang_macro_fallback_build_dir: Option<PathBuf> {
         methods: {
-            /// Set a path to a directory to which `.c` and `.h.pch` files should be written for the
-            /// purpose of using clang to evaluate macros that can't be easily parsed.
+            /// Set a path to a directory under which scratch `.c` and `.h.pch` files should be
+            /// written for the purpose of using clang to evaluate macros that can't be easily
+            /// parsed.
             ///
-            /// The default location for `.h.pch` files is the directory that the corresponding
-            /// `.h` file is located in. The default for the temporary `.c` file used for clang
-            /// parsing is the current working directory. Both of these defaults are overridden
-            /// by this option.
+            /// A private subdirectory is created under this path for each fallback translation
+            /// unit. By default, the current working directory is used.
             pub fn clang_macro_fallback_build_dir<P: AsRef<Path>>(mut self, path: P) -> Self {
                 self.options.clang_macro_fallback_build_dir = Some(path.as_ref().to_owned());
                 self


### PR DESCRIPTION
## Summary

Fixes #3351.

`clang_macro_fallback()` builds a fallback translation unit from the input headers. When the user only provides input through `header_contents()`, `input_headers` is empty, so fallback setup returns `None` and macros that need fallback evaluation are silently skipped.

Keep `input_header_contents` available to the generation context, materialize those virtual headers as temporary fallback headers while the PCH is alive, and include them in the fallback PCH setup.

The implicit `--target` fix from the original version of this PR was split out to #3382.