### PR TITLE
fix: resolve bitfield accessor name conflicts

### DIFF
--- a/bindgen-tests/tests/expectations/tests/bitfield-accessor-name-conflict.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-accessor-name-conflict.rs
@@ -488,107 +488,178 @@ impl<const N: usize> __BindgenBitfieldUnit<[u8; N]> {
         }
     }
 }
-/** Because this struct have array larger than 32 items
- and --with-derive-partialeq --impl-partialeq --impl-debug is provided,
- this struct should manually implement `Debug` and `PartialEq`.*/
+/** Bitfield accessor name conflicts:
+ - `set_x` getter collides with `x` setter
+ - `set_x_bindgen_bitfield` tests the collision chain (the suffix
+   used for deduplication itself collides with a real field name)*/
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct Foo {
-    pub large: [::std::os::raw::c_int; 33usize],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
-    pub __bindgen_padding_0: u16,
+#[derive(Debug, Default, Copy, Clone)]
+pub struct test {
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Foo"][::std::mem::size_of::<Foo>() - 136usize];
-    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
-    ["Offset of field: Foo::large"][::std::mem::offset_of!(Foo, large) - 0usize];
+    ["Size of test"][::std::mem::size_of::<test>() - 1usize];
+    ["Alignment of test"][::std::mem::align_of::<test>() - 1usize];
 };
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo4typeEv"]
-    pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_char;
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo9set_type_Ec"]
-    pub fn Foo_set_type_(this: *mut Foo, c: ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo8set_typeEc"]
-    pub fn Foo_set_type(this: *mut Foo, c: ::std::os::raw::c_char);
-}
-impl Default for Foo {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl Foo {
+impl test {
     #[inline]
-    pub fn type_(&self) -> ::std::os::raw::c_char {
+    pub fn set_x(&self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
-    pub fn set_type_(&mut self, val: ::std::os::raw::c_char) {
+    pub fn set_set_x(&mut self, val: ::std::os::raw::c_char) {
         unsafe {
             let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
         }
     }
     #[inline]
-    pub unsafe fn type__raw(this: *const Self) -> ::std::os::raw::c_char {
+    pub unsafe fn set_x_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 2usize],
+                    [u8; 1usize],
                 >>::raw_get_const::<
                     0usize,
-                    3u8,
+                    1u8,
                 >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_type__raw(this: *mut Self, val: ::std::os::raw::c_char) {
+    pub unsafe fn set_set_x_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
             let val: u8 = val as _;
             <__BindgenBitfieldUnit<
-                [u8; 2usize],
+                [u8; 1usize],
             >>::raw_set_const::<
                 0usize,
-                3u8,
+                1u8,
+            >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
+        }
+    }
+    #[inline]
+    pub fn x_bindgen_bitfield(&self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
+        }
+    }
+    #[inline]
+    pub fn set_x_bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = val as _;
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn x_bindgen_bitfield_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_x_bindgen_bitfield_raw(
+        this: *mut Self,
+        val: ::std::os::raw::c_char,
+    ) {
+        unsafe {
+            let val: u8 = val as _;
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set_const::<
+                1usize,
+                1u8,
+            >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
+        }
+    }
+    #[inline]
+    pub fn set_x_bindgen_bitfield_bindgen_bitfield(&self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
+        }
+    }
+    #[inline]
+    pub fn set_set_x_bindgen_bitfield_bindgen_bitfield(
+        &mut self,
+        val: ::std::os::raw::c_char,
+    ) {
+        unsafe {
+            let val: u8 = val as _;
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_x_bindgen_bitfield_bindgen_bitfield_raw(
+        this: *const Self,
+    ) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_set_x_bindgen_bitfield_bindgen_bitfield_raw(
+        this: *mut Self,
+        val: ::std::os::raw::c_char,
+    ) {
+        unsafe {
+            let val: u8 = val as _;
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set_const::<
+                2usize,
+                1u8,
             >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
         }
     }
     #[inline]
     pub fn new_bitfield_1(
-        type_: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
+        set_x: ::std::os::raw::c_char,
+        x_bindgen_bitfield: ::std::os::raw::c_char,
+        set_x_bindgen_bitfield_bindgen_bitfield: ::std::os::raw::c_char,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
             .set_const::<
                 0usize,
-                3u8,
+                1u8,
             >({
-                let type_: u8 = type_ as _;
-                type_ as u64
+                let set_x: u8 = set_x as _;
+                set_x as u64
             });
         __bindgen_bitfield_unit
-    }
-    #[inline]
-    pub unsafe fn type_1(&mut self) -> ::std::os::raw::c_char {
-        Foo_type(self)
-    }
-    #[inline]
-    pub unsafe fn set_type_1(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type_(self, c)
-    }
-    #[inline]
-    pub unsafe fn set_type(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type(self, c)
+            .set_const::<
+                1usize,
+                1u8,
+            >({
+                let x_bindgen_bitfield: u8 = x_bindgen_bitfield as _;
+                x_bindgen_bitfield as u64
+            });
+        __bindgen_bitfield_unit
+            .set_const::<
+                2usize,
+                1u8,
+            >({
+                let set_x_bindgen_bitfield_bindgen_bitfield: u8 = set_x_bindgen_bitfield_bindgen_bitfield
+                    as _;
+                set_x_bindgen_bitfield_bindgen_bitfield as u64
+            });
+        __bindgen_bitfield_unit
     }
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -512,22 +512,20 @@ unsafe extern "C" {
 }
 impl Foo {
     #[inline]
-    pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
+    pub fn type_(&self) -> ::std::os::raw::c_char {
         unsafe {
             ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
         }
     }
     #[inline]
-    pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
+    pub fn set_type_(&mut self, val: ::std::os::raw::c_char) {
         unsafe {
             let val: u8 = val as _;
             self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
         }
     }
     #[inline]
-    pub unsafe fn type__bindgen_bitfield_raw(
-        this: *const Self,
-    ) -> ::std::os::raw::c_char {
+    pub unsafe fn type__raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
@@ -540,10 +538,7 @@ impl Foo {
         }
     }
     #[inline]
-    pub unsafe fn set_type__bindgen_bitfield_raw(
-        this: *mut Self,
-        val: ::std::os::raw::c_char,
-    ) {
+    pub unsafe fn set_type__raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
             let val: u8 = val as _;
             <__BindgenBitfieldUnit<
@@ -556,7 +551,7 @@ impl Foo {
     }
     #[inline]
     pub fn new_bitfield_1(
-        type__bindgen_bitfield: ::std::os::raw::c_char,
+        type_: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -564,17 +559,17 @@ impl Foo {
                 0usize,
                 3u8,
             >({
-                let type__bindgen_bitfield: u8 = type__bindgen_bitfield as _;
-                type__bindgen_bitfield as u64
+                let type_: u8 = type_ as _;
+                type_ as u64
             });
         __bindgen_bitfield_unit
     }
     #[inline]
-    pub unsafe fn type_(&mut self) -> ::std::os::raw::c_char {
+    pub unsafe fn type_1(&mut self) -> ::std::os::raw::c_char {
         Foo_type(self)
     }
     #[inline]
-    pub unsafe fn set_type_(&mut self, c: ::std::os::raw::c_char) {
+    pub unsafe fn set_type_1(&mut self, c: ::std::os::raw::c_char) {
         Foo_set_type_(self, c)
     }
     #[inline]

--- a/bindgen-tests/tests/headers/bitfield-accessor-name-conflict.h
+++ b/bindgen-tests/tests/headers/bitfield-accessor-name-conflict.h
@@ -1,0 +1,9 @@
+/// Bitfield accessor name conflicts:
+/// - `set_x` getter collides with `x` setter
+/// - `set_x_bindgen_bitfield` tests the collision chain (the suffix
+///   used for deduplication itself collides with a real field name)
+struct test {
+    char set_x: 1;
+    char x: 1;
+    char set_x_bindgen_bitfield: 1;
+};

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -564,6 +564,131 @@ fn test_mixed_header_and_header_contents() {
 }
 
 #[test]
+fn test_bitfield_accessor_name_conflict_torture() {
+    // This deliberately mixes first-order accessor collisions, repeated
+    // suffix chains, raw-name collisions, reversed declaration order,
+    // and C++ methods whose names only collide after suffixing.
+    let header = r"
+struct BasicPair {
+    char set_x : 1;
+    char x : 1;
+};
+
+struct GetterSetterChain {
+    char x : 1;
+    char set_x : 1;
+    char set_x_bindgen_bitfield : 1;
+};
+
+struct RawGetterSetterChain {
+    char x : 1;
+    char set_x_raw : 1;
+    char set_x_raw_bindgen_bitfield : 1;
+};
+
+struct ReverseGetterSetterChain {
+    char set_x_bindgen_bitfield : 1;
+    char set_x : 1;
+    char x : 1;
+};
+
+struct ReverseRawGetterSetterChain {
+    char set_x_raw_bindgen_bitfield : 1;
+    char set_x_raw : 1;
+    char x : 1;
+};
+
+struct MethodAfterAccessorCollision {
+    char x : 1;
+    char set_x : 1;
+    void set_x_bindgen_bitfield();
+    void set_set_x_bindgen_bitfield(char c);
+};
+
+struct MethodAfterRawCollision {
+    char x : 1;
+    char set_x_raw : 1;
+    void set_x_raw_bindgen_bitfield();
+    void set_set_x_raw_bindgen_bitfield(char c);
+};
+
+struct MethodCollisionChain {
+    char type_ : 1;
+    char set_type : 1;
+    char set_type_bindgen_bitfield : 1;
+    char type();
+    void set_type_(char c);
+    void set_set_type_bindgen_bitfield(char c);
+};
+
+struct OverloadedMethodConflict {
+    char foo1 : 1;
+    char bar : 1;
+    void foo();
+    void foo(int);
+};
+
+struct DtorConflict {
+    char destruct : 1;
+    ~DtorConflict();
+};
+
+struct DtorShiftConflict {
+    char destruct1 : 1;
+    void destruct();
+    ~DtorShiftConflict();
+};
+
+struct CtorConflict {
+    char new_ : 1;
+    CtorConflict();
+    CtorConflict(int);
+};
+
+struct CtorShiftConflict {
+    char new1 : 1;
+    CtorShiftConflict();
+    CtorShiftConflict(int);
+};
+";
+
+    let bindings = builder()
+        .disable_header_comment()
+        .header_contents("bitfield_accessor_name_conflict_torture.hpp", header)
+        .clang_arg("-xc++")
+        .clang_arg("--target=x86_64-unknown-linux")
+        .generate()
+        .unwrap()
+        .to_string();
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let source = tmpdir.path().join("bindings.rs");
+    let output = tmpdir.path().join("libbindings.rlib");
+    fs::write(&source, &bindings).unwrap();
+
+    let rustc = env::var_os("RUSTC")
+        .unwrap_or_else(|| std::ffi::OsString::from("rustc"));
+    // Duplicate accessors still parse as Rust, so compile the generated
+    // bindings instead of only formatting/parsing them.
+    let compile = std::process::Command::new(rustc)
+        .arg("--crate-type=lib")
+        .arg("--edition=2021")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .unwrap();
+
+    assert!(
+        compile.status.success(),
+        "Generated bindings did not compile.\nstdout:\n{}\nstderr:\n{}\nbindings:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr),
+        bindings,
+    );
+}
+
+#[test]
 fn test_macro_fallback_non_system_dir() {
     let actual = builder()
         .header(concat!(

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2783,7 +2783,26 @@ impl CodeGenerator for CompInfo {
                 }
             }
 
-            let mut method_names = Default::default();
+            // Seed method_names with bitfield accessor names so C++
+            // methods, constructors, and destructors that collide with
+            // them get renamed instead of producing duplicates.
+            let mut method_names: HashSet<String> = self
+                .fields()
+                .iter()
+                .filter_map(|f| match f {
+                    Field::Bitfields(ref bu) => Some(bu.bitfields().iter()),
+                    Field::DataMember(_) => None,
+                })
+                .flatten()
+                .filter(|bf| bf.name().is_some())
+                .flat_map(|bf| {
+                    let g = bf.getter_name().to_owned();
+                    let s = bf.setter_name().to_owned();
+                    let gr = format!("{g}_raw");
+                    let sr = format!("{s}_raw");
+                    [g, s, gr, sr]
+                })
+                .collect();
             let discovered_id = DiscoveredItemId::new(item.id().as_usize());
             if ctx.options().codegen_config.methods() {
                 for method in self.methods() {
@@ -3125,6 +3144,12 @@ impl Method {
         if signature.is_variadic() {
             return;
         }
+
+        // Mangle the name before dedup so we compare the actual Rust
+        // identifier (e.g. C++ `type` → Rust `type_`) against
+        // method_names, which contains bitfield accessor names that
+        // are already in their Rust-mangled form.
+        name = ctx.rust_mangle(&name).to_string();
 
         if method_names.contains(&name) {
             let mut count = 1;

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -15,8 +15,8 @@ use crate::clang;
 use crate::codegen::struct_layout::align_to;
 use crate::ir::derive::CanDeriveCopy;
 use crate::parse::ParseError;
-use crate::HashMap;
 use crate::NonCopyUnionStyle;
+use crate::{HashMap, HashSet};
 use std::cmp;
 use std::io;
 use std::mem;
@@ -703,7 +703,7 @@ impl CompFields {
         }
     }
 
-    fn deanonymize_fields(&mut self, ctx: &BindgenContext, methods: &[Method]) {
+    fn deanonymize_fields(&mut self, ctx: &BindgenContext) {
         let fields = match *self {
             CompFields::After { ref mut fields, .. } => fields,
             // Nothing to do here.
@@ -713,50 +713,68 @@ impl CompFields {
             }
         };
 
-        fn has_method(
-            methods: &[Method],
-            ctx: &BindgenContext,
-            name: &str,
-        ) -> bool {
-            methods.iter().any(|method| {
-                let method_name = ctx.resolve_func(method.signature()).name();
-                method_name == name || ctx.rust_mangle(method_name) == name
-            })
-        }
-
         struct AccessorNamesPair {
             getter: String,
             setter: String,
         }
 
-        let mut accessor_names: HashMap<String, AccessorNamesPair> = fields
+        // Build accessor names for each bitfield, resolving
+        // inter-bitfield collisions. Method/constructor/destructor
+        // collisions are handled in codegen by seeding method_names
+        // with bitfield accessor names before emitting C++ methods.
+        //
+        // Names are suffixed with `_bindgen_bitfield` repeatedly until
+        // unique, handling chains like `x` / `set_x` /
+        // `set_x_bindgen_bitfield`.
+        let mut accessor_names: HashMap<String, AccessorNamesPair> =
+            Default::default();
+        let mut used_names: HashSet<String> = Default::default();
+
+        let bitfield_names: Vec<String> = fields
             .iter()
             .flat_map(|field| match *field {
                 Field::Bitfields(ref bu) => &*bu.bitfields,
                 Field::DataMember(_) => &[],
             })
             .filter_map(|bitfield| bitfield.name())
-            .map(|bitfield_name| {
-                let bitfield_name = bitfield_name.to_string();
-                let getter = {
-                    let mut getter =
-                        ctx.rust_mangle(&bitfield_name).to_string();
-                    if has_method(methods, ctx, &getter) {
-                        getter.push_str("_bindgen_bitfield");
-                    }
-                    getter
-                };
-                let setter = {
-                    let setter = format!("set_{bitfield_name}");
-                    let mut setter = ctx.rust_mangle(&setter).to_string();
-                    if has_method(methods, ctx, &setter) {
-                        setter.push_str("_bindgen_bitfield");
-                    }
-                    setter
-                };
-                (bitfield_name, AccessorNamesPair { getter, setter })
-            })
+            .map(|n| n.to_string())
             .collect();
+
+        for bitfield_name in &bitfield_names {
+            let mut getter = ctx.rust_mangle(bitfield_name).to_string();
+            let mut setter = {
+                let s = format!("set_{bitfield_name}");
+                ctx.rust_mangle(&s).to_string()
+            };
+
+            // Resolve collisions against previously assigned bitfield
+            // accessor names. Check all four variants (getter, setter,
+            // and their _raw forms) and keep suffixing until unique.
+            loop {
+                let all_unique = [
+                    &getter,
+                    &setter,
+                    &format!("{getter}_raw"),
+                    &format!("{setter}_raw"),
+                ]
+                .iter()
+                .all(|n| !used_names.contains(n.as_str()));
+                if all_unique {
+                    break;
+                }
+                getter.push_str("_bindgen_bitfield");
+                setter.push_str("_bindgen_bitfield");
+            }
+
+            used_names.insert(getter.clone());
+            used_names.insert(setter.clone());
+            used_names.insert(format!("{getter}_raw"));
+            used_names.insert(format!("{setter}_raw"));
+            accessor_names.insert(
+                bitfield_name.clone(),
+                AccessorNamesPair { getter, setter },
+            );
+        }
 
         let mut anon_field_counter = 0;
         for field in fields.iter_mut() {
@@ -1701,7 +1719,7 @@ impl CompInfo {
 
     /// Assign for each anonymous field a generated name.
     pub(crate) fn deanonymize_fields(&mut self, ctx: &BindgenContext) {
-        self.fields.deanonymize_fields(ctx, &self.methods);
+        self.fields.deanonymize_fields(ctx);
     }
 
     /// Returns whether the current union can be represented as a Rust `union`

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -11,7 +11,6 @@ use super::derive::{
     CanDerive, CanDeriveCopy, CanDeriveDebug, CanDeriveDefault, CanDeriveEq,
     CanDeriveHash, CanDeriveOrd, CanDerivePartialEq, CanDerivePartialOrd,
 };
-use super::function::Function;
 use super::int::IntKind;
 use super::item::{IsOpaque, Item, ItemAncestors, ItemSet};
 use super::item_kind::ItemKind;
@@ -1454,14 +1453,6 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     /// item is not a `Type`.
     pub(crate) fn resolve_type(&self, type_id: TypeId) -> &Type {
         self.resolve_item(type_id).kind().expect_type()
-    }
-
-    /// Resolve a function with the given ID.
-    ///
-    /// Panics if there is no item for the given `FunctionId` or if the resolved
-    /// item is not a `Function`.
-    pub(crate) fn resolve_func(&self, func_id: FunctionId) -> &Function {
-        self.resolve_item(func_id).kind().expect_function()
     }
 
     /// Resolve the given `ItemId` as a type, or `None` if there is no item with


### PR DESCRIPTION
## Summary

Fixes #3322

When a struct has bitfields like `x` and `set_x`, the generated getter for `set_x` collides with the generated setter for `x` (both named `set_x`), producing duplicate method definitions that fail to compile.

## Root cause

Bitfield accessor name dedup only checked against C++ methods (`has_method`), not against other bitfield accessors, and codegen's method/constructor/destructor emission had no knowledge of bitfield accessor names at all. This left several collision classes unhandled:

- Two bitfields whose accessor names overlap (`x` + `set_x`)
- Overloaded C++ methods whose numbered Rust names (`foo1`) collide with a bitfield
- Destructors (`destruct`) and constructors (`new`, `new1`) colliding with bitfields
- `_raw` accessor variant collisions (`set_x_raw` vs bitfield `set_x_raw`)
- Rust keyword mangling (`type` → `type_`) not considered during method dedup

## Fix

**IR phase** (`comp.rs`): resolve inter-bitfield accessor collisions by tracking all assigned names (getter, setter, and `_raw` variants) and suffixing with `_bindgen_bitfield` until unique. Handles chains like `x` / `set_x` / `set_x_bindgen_bitfield`.

**Codegen phase** (`mod.rs`): seed the `method_names` set with bitfield accessor names before emitting C++ methods, constructors, and destructors. The existing method dedup mechanism then renames colliding wrappers instead of producing duplicates. Method names are Rust-mangled before dedup so keyword collisions (e.g. C++ `type` → Rust `type_`) are caught.

The behavior change: bitfield accessors keep their natural names, and colliding C++ method/ctor/dtor wrappers get numeric suffixes (`type_1`, `destruct1`, etc.).
