### PR TITLE
ci: Move forward Rust for Linux version to v7.1-rc1

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -99,7 +99,7 @@ if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
   # and each update should only contain this change.
   #
   # Both commit hashes and tags are supported.
-  LINUX_VERSION=v6.19
+  LINUX_VERSION=v7.1-rc1
 
   # Download Linux at a specific commit
   mkdir -p linux


### PR DESCRIPTION
Linux v7.1 will have our new MSRVs: Rust 1.85.0 and `bindgen` 0.71.1.