### PR TITLE
Add Isize and Usize IntKinds for use in ParseCallbacks::int_macro

### DIFF
--- a/bindgen/codegen/helpers.rs
+++ b/bindgen/codegen/helpers.rs
@@ -219,6 +219,8 @@ pub(crate) mod ast_ty {
             IntKind::U32 => syn::parse_quote! { u32 },
             IntKind::I64 => syn::parse_quote! { i64 },
             IntKind::U64 => syn::parse_quote! { u64 },
+            IntKind::Isize => syn::parse_quote! { isize },
+            IntKind::Usize => syn::parse_quote! { usize },
             IntKind::Custom { name, .. } => {
                 syn::parse_str(name).expect("Invalid integer type.")
             }

--- a/bindgen/ir/int.rs
+++ b/bindgen/ir/int.rs
@@ -78,6 +78,12 @@ pub enum IntKind {
     /// A `uint128_t`.
     U128,
 
+    /// A pointer-sized signed integer.
+    Isize,
+
+    /// A pointer-sized unsigned integer.
+    Usize,
+
     /// A custom integer type, used to allow custom macro types depending on
     /// range.
     Custom {
@@ -97,10 +103,10 @@ impl IntKind {
             // to know whether it is or not right now (unlike char, there's no
             // WChar_S / WChar_U).
             Bool | UChar | UShort | UInt | ULong | ULongLong | U8 | U16 |
-            Char16 | WChar | U32 | U64 | U128 => false,
+            Char16 | WChar | U32 | U64 | U128 | Usize => false,
 
             SChar | Short | Int | Long | LongLong | I8 | I16 | I32 | I64 |
-            I128 => true,
+            I128 | Isize => true,
 
             Char { is_signed } | Custom { is_signed, .. } => is_signed,
         }


### PR DESCRIPTION
C macros are often used to define array/buffer size constants. In Rust, representing these as `usize` is more natural than the fixed-bit-size integer types, because it allows indexing and comparisons without casting.

I also added `isize` while I was at it. Using these types is already possible via `IntKind::Custom`, but given they are built-in integer types like `u64` and `i64`, I figured having a separate enum variant would be appropriate.