### PR TITLE
fix: use ptr::add() instead of ptr::offset() in bitfield_unit

### DIFF
--- a/bindgen/codegen/bitfield_unit.rs
+++ b/bindgen/codegen/bitfield_unit.rs
@@ -45,7 +45,7 @@ where
         let byte_index = index / 8;
         let byte = unsafe {
             *(core::ptr::addr_of!((*this).storage) as *const u8)
-                .offset(byte_index as isize)
+                .add(byte_index)
         };
 
         Self::extract_bit(byte, index)
@@ -84,7 +84,7 @@ where
         let byte_index = index / 8;
         let byte = unsafe {
             (core::ptr::addr_of_mut!((*this).storage) as *mut u8)
-                .offset(byte_index as isize)
+                .add(byte_index)
         };
 
         unsafe { *byte = Self::change_bit(*byte, index, val) };


### PR DESCRIPTION
## Summary

Replace `.offset(byte_index as isize)` with `.add(byte_index)` in the `__BindgenBitfieldUnit` template's `raw_get_bit` and `raw_set_bit` methods.

## Motivation

The `byte_index` variable is always a non-negative `usize` (computed as `index / 8`). Using `.offset(byte_index as isize)` triggers the `clippy::ptr_offset_with_cast` lint in all downstream crates that compile the generated `bindings.rs` with clippy, because the cast from `usize` to `isize` is unnecessary and potentially lossy on platforms where `usize::MAX > isize::MAX`.

Using `.add(byte_index)` is semantically identical (both advance the pointer by `byte_index` bytes) but avoids the lint and makes the intent clearer: we are always advancing forward by a non-negative offset.

## Changes

- `bindgen/codegen/bitfield_unit.rs`: Two instances of `.offset(byte_index as isize)` → `.add(byte_index)` in `raw_get_bit` and `raw_set_bit`.

Note: The `raw_get`, `raw_set`, `raw_get_const`, and `raw_set_const` methods already use `.add()` correctly — this fix brings the two remaining `raw_*_bit` methods into alignment.