### PR TITLE
Add `libcpp` feature

### DIFF
--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -32,6 +32,7 @@ shlex.workspace = true
 default = ["logging", "runtime"]
 logging = ["bindgen/logging", "dep:env_logger", "dep:log"]
 static = ["bindgen/static"]
+libcpp = ["bindgen/libcpp"]
 runtime = ["bindgen/runtime"]
 prettyplease = ["bindgen/prettyplease"]
 

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -46,6 +46,7 @@ syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
 default = ["logging", "prettyplease", "runtime"]
 logging = ["dep:log"]
 static = ["clang-sys/static"]
+libcpp = ["clang-sys/libcpp"]
 runtime = ["clang-sys/runtime"]
 experimental = ["dep:annotate-snippets"]
 


### PR DESCRIPTION
This adds a `libcpp` feature, which in turn enables `libcpp` from the `clang-sys` crate. This allows bindgen to use `libc++` from LLVM instead of the system c++ standard library.