### PR TITLE
Upgrade shlex to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 2.0.1",
  "syn",
 ]
 
@@ -100,7 +100,7 @@ dependencies = [
  "env_logger 0.10.2",
  "log",
  "proc-macro2",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "regex",
- "shlex",
+ "shlex 2.0.1",
  "similar",
  "syn",
  "tempfile",
@@ -144,7 +144,7 @@ version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
@@ -557,6 +557,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "similar"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 2.0.1",
+ "shlex",
  "syn",
 ]
 
@@ -100,7 +100,7 @@ dependencies = [
  "env_logger 0.10.2",
  "log",
  "proc-macro2",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -120,7 +120,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "regex",
- "shlex 2.0.1",
+ "shlex",
  "similar",
  "syn",
  "tempfile",
@@ -140,11 +140,12 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
- "shlex 1.3.0",
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -272,6 +273,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "getrandom"
@@ -551,12 +558,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ quickcheck = "1.0"
 quote = { version = "1", default-features = false }
 regex = { version = "1.5.3", default-features = false }
 rustc-hash = "2.1.0"
-shlex = "1"
+shlex = "2"
 similar = "2.2.1"
 syn = "2.0"
 tempfile = "3.27.0"


### PR DESCRIPTION
The cc crate already upgraded to shlex 2.x. Bumping our dependency avoids having both shlex 1.x and 2.x in the lock file.

This also pulls in the soundness fix in comex/rust-shlex#26, which this project was not affected by.