### PR TITLE
Avoid IR cycle for compiler-builtin ObjC typedefs shadowing themselves

### DIFF
--- a/bindgen-tests/tests/expectations/tests/objc_builtin_typedef_cycle.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_builtin_typedef_cycle.rs
@@ -1,0 +1,56 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+use objc::{self, msg_send, sel, sel_impl, class};
+#[allow(non_camel_case_types)]
+pub type id = *mut objc::runtime::Object;
+#[repr(C)]
+#[derive(Debug)]
+pub struct objc_class {
+    _unused: [u8; 0],
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct Class(pub id);
+impl std::ops::Deref for Class {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for Class {}
+impl Class {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(class!(Class), alloc) })
+    }
+}
+impl IClass for Class {}
+pub trait IClass: Sized + std::ops::Deref {}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct objc_object {
+    pub isa: Class,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of objc_object"][::std::mem::size_of::<objc_object>() - 8usize];
+    ["Alignment of objc_object"][::std::mem::align_of::<objc_object>() - 8usize];
+    [
+        "Offset of field: objc_object::isa",
+    ][::std::mem::offset_of!(objc_object, isa) - 0usize];
+};
+impl Default for objc_object {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+pub trait PFoo: Sized + std::ops::Deref {
+    unsafe fn foo(&self) -> id
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(* self, foo)
+    }
+}

--- a/bindgen-tests/tests/headers/objc_builtin_typedef_cycle.h
+++ b/bindgen-tests/tests/headers/objc_builtin_typedef_cycle.h
@@ -1,0 +1,7 @@
+// bindgen-flags: -- -x objective-c -isystem tests/headers/support/objc-builtin-typedef-cycle
+
+#include <system-objc.h>
+
+@protocol Foo
+- (id)foo;
+@end

--- a/bindgen-tests/tests/headers/support/objc-builtin-typedef-cycle/system-objc.h
+++ b/bindgen-tests/tests/headers/support/objc-builtin-typedef-cycle/system-objc.h
@@ -1,0 +1,9 @@
+/* Minimal stand-in for a platform SDK's objc/objc.h: a typedef that
+ * shadows a compiler builtin ObjC type by aliasing its own underlying
+ * representation. Included via `-isystem` so clang treats it as a system
+ * header, matching how real SDKs provide it. */
+typedef struct objc_class *Class;
+struct objc_object {
+    Class isa;
+};
+typedef struct objc_object *id;

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -1068,6 +1068,39 @@ impl Type {
                 }
                 CXType_Typedef => {
                     let inner = cursor.typedef_type().expect("Not valid Type?");
+
+                    // Some compiler builtins (Objective-C's `id`, `SEL`,
+                    // `Class`) can also be redeclared via a same-named
+                    // typedef aliasing their underlying representation (see
+                    // e.g. objc/objc.h's `#if !OBJC_TYPES_DEFINED` block,
+                    // meant to avoid clashing when the builtins aren't
+                    // already provided by the compiler). Depending on
+                    // libclang's version, asking such a typedef for its
+                    // underlying type can report the *same* declaration
+                    // (identical USR) back instead of desugaring to the
+                    // written-out type. Treating that as an ordinary
+                    // `Alias` would make this type indirectly reference
+                    // itself once bindgen's deferred `resolve_typerefs`
+                    // finishes resolving the "already resolved" builtin
+                    // lookup, looping forever when e.g. computing its
+                    // canonical type. Detect the same-USR case up front and
+                    // resolve directly as the inner kind instead of
+                    // aliasing to it, exactly as we would if `ty` itself had
+                    // reported that kind.
+                    let same_underlying_decl = matches!(
+                        (cursor.usr(), inner.declaration().usr()),
+                        (Some(outer), Some(inner)) if outer == inner
+                    );
+                    if same_underlying_decl {
+                        return Self::from_clang_ty(
+                            potential_id,
+                            &inner,
+                            location,
+                            parent_id,
+                            ctx,
+                        );
+                    }
+
                     let inner_id =
                         Item::from_ty_or_ref(inner, location, None, ctx);
                     if inner_id == potential_id {


### PR DESCRIPTION
Objective-C's id/SEL/Class are compiler builtins, but SDK headers also redeclare them via a same-named typedef.

Under clang 22, asking such a typedef for its underlying type reports back the same declaration instead of desugaring to the written-out type. Treating that as an ordinary Alias creates a cycle once resolve_typerefs resolves the deferred reference, and nothing that computes canonical types checks for cycles, so it recurses forever - a stack overflow, or an infinite loop if the recursion gets tail-call-optimized.

Detect the same-USR case in CXType_Typedef handling and resolve directly as the inner kind instead of aliasing to it, so the cycle is never constructed.

Adds a self-contained regression test (the typedef lives in an auxiliary header included via -isystem, so it doesn't need a real macOS SDK) that segfaults on main and passes with this fix.

Fixes #3386