### PR TITLE
Fix unnecessary transmute and unnecessary unsafe block warnings on bitfield codegen

### DIFF
--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -519,28 +519,20 @@ const _: () = {
 impl MuchBitfield {
     #[inline]
     pub fn m0(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m0(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m0_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -557,28 +549,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m1(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m1(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m1_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -595,28 +579,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m2(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m2(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m2_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -633,28 +609,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m3(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<3usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m3(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m3_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    3usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -671,28 +639,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m4(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<4usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m4(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m4_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    4usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -709,28 +669,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m5(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<5usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m5(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m5_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    5usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -747,28 +699,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m6(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<6usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m6(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m6_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    6usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -785,28 +729,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m7(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<7usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m7(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m7_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    7usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -823,28 +759,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m8(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<8usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m8(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m8_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    8usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -861,28 +789,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m9(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<9usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m9(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m9_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    9usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -899,28 +819,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m10(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<10usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m10(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m10_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    10usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<10usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -937,28 +849,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m11(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<11usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m11(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m11_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    11usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<11usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -975,28 +879,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m12(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<12usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m12(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m12_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    12usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<12usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1013,28 +909,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m13(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<13usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<13usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m13(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m13_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    13usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<13usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1051,28 +939,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m14(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<14usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m14(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m14_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    14usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<14usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1089,28 +969,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m15(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<15usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<15usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m15(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m15_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    15usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<15usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1127,28 +999,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m16(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<16usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m16(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m16_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    16usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<16usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1165,28 +1029,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m17(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<17usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<17usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m17(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m17_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    17usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<17usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1203,28 +1059,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m18(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<18usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<18usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m18(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m18_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    18usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<18usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1241,28 +1089,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m19(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<19usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<19usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m19(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m19_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    19usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<19usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1279,28 +1119,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m20(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<20usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m20(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m20_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    20usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<20usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1317,28 +1149,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m21(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<21usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<21usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m21(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m21_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    21usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<21usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1355,28 +1179,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m22(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<22usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<22usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m22(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m22_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    22usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<22usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1393,28 +1209,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m23(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<23usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<23usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m23(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m23_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    23usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1431,28 +1239,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m24(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<24usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m24(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m24_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    24usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<24usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1469,28 +1269,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m25(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<25usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<25usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m25(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m25_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    25usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<25usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1507,28 +1299,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m26(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<26usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<26usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m26(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m26_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    26usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<26usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1545,28 +1329,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m27(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<27usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<27usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m27(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m27_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    27usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<27usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1583,28 +1359,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m28(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<28usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<28usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m28(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m28_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    28usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<28usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1621,28 +1389,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m29(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<29usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<29usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m29(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m29_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    29usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<29usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1659,28 +1419,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m30(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<30usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<30usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m30(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m30_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    30usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<30usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1697,28 +1449,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m31(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<31usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m31(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m31_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    31usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1735,28 +1479,20 @@ impl MuchBitfield {
     }
     #[inline]
     pub fn m32(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<32usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_m32(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m32_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 5usize],
-                >>::raw_get_const::<
-                    32usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 5usize],
+            >>::raw_get_const::<32usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -520,28 +520,20 @@ const _: () = {
 impl HasBigBitfield {
     #[inline]
     pub fn x(&self) -> i128 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 128u8>() as u128)
-        }
+        self._bitfield_1.get_const::<0usize, 128u8>() as u128 as _
     }
     #[inline]
     pub fn set_x(&mut self, val: i128) {
-        unsafe {
-            let val: u128 = val as _;
-            self._bitfield_1.set_const::<0usize, 128u8>(val as u64)
-        }
+        let val: u128 = val as _;
+        self._bitfield_1.set_const::<0usize, 128u8>(val as u64)
     }
     #[inline]
     pub unsafe fn x_raw(this: *const Self) -> i128 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    0usize,
-                    128u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<0usize, 128u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u128 as _
         }
     }
     #[inline]
@@ -588,28 +580,20 @@ const _: () = {
 impl HasTwoBigBitfields {
     #[inline]
     pub fn x(&self) -> i128 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 80u8>() as u128)
-        }
+        self._bitfield_1.get_const::<0usize, 80u8>() as u128 as _
     }
     #[inline]
     pub fn set_x(&mut self, val: i128) {
-        unsafe {
-            let val: u128 = val as _;
-            self._bitfield_1.set_const::<0usize, 80u8>(val as u64)
-        }
+        let val: u128 = val as _;
+        self._bitfield_1.set_const::<0usize, 80u8>(val as u64)
     }
     #[inline]
     pub unsafe fn x_raw(this: *const Self) -> i128 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    0usize,
-                    80u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<0usize, 80u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u128 as _
         }
     }
     #[inline]
@@ -626,28 +610,20 @@ impl HasTwoBigBitfields {
     }
     #[inline]
     pub fn y(&self) -> i128 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<80usize, 48u8>() as u128)
-        }
+        self._bitfield_1.get_const::<80usize, 48u8>() as u128 as _
     }
     #[inline]
     pub fn set_y(&mut self, val: i128) {
-        unsafe {
-            let val: u128 = val as _;
-            self._bitfield_1.set_const::<80usize, 48u8>(val as u64)
-        }
+        let val: u128 = val as _;
+        self._bitfield_1.set_const::<80usize, 48u8>(val as u64)
     }
     #[inline]
     pub unsafe fn y_raw(this: *const Self) -> i128 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    80usize,
-                    48u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<80usize, 48u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u128 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -515,28 +515,20 @@ pub struct Test {
 impl Test {
     #[inline]
     pub fn x(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 56u8>() as u64)
-        }
+        self._bitfield_1.get_const::<0usize, 56u8>() as u64 as _
     }
     #[inline]
     pub fn set_x(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<0usize, 56u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<0usize, 56u8>(val as u64)
     }
     #[inline]
     pub unsafe fn x_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    0usize,
-                    56u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<0usize, 56u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -553,28 +545,20 @@ impl Test {
     }
     #[inline]
     pub fn y(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<56usize, 8u8>() as u64)
-        }
+        self._bitfield_1.get_const::<56usize, 8u8>() as u64 as _
     }
     #[inline]
     pub fn set_y(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<56usize, 8u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<56usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn y_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    56usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<56usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -531,30 +531,22 @@ unsafe extern "C" {
 impl Foo {
     #[inline]
     pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 3u8>() as u8 as _
     }
     #[inline]
     pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn type__bindgen_bitfield_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield-template.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-template.rs
@@ -525,28 +525,20 @@ impl<T> Default for foo<T> {
 impl<T> foo<T> {
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 8u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 8u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 8u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -524,28 +524,20 @@ const _: () = {
 impl A {
     #[inline]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -562,28 +554,20 @@ impl A {
     }
     #[inline]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -600,28 +584,20 @@ impl A {
     }
     #[inline]
     pub fn b3(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b3(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -638,28 +614,20 @@ impl A {
     }
     #[inline]
     pub fn b4(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<3usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b4(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b4_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    3usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -676,28 +644,20 @@ impl A {
     }
     #[inline]
     pub fn b5(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b5(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b5_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    4usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -714,28 +674,20 @@ impl A {
     }
     #[inline]
     pub fn b6(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<5usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b6(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b6_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    5usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -752,28 +704,20 @@ impl A {
     }
     #[inline]
     pub fn b7(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<6usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b7(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b7_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    6usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -790,28 +734,20 @@ impl A {
     }
     #[inline]
     pub fn b8(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<7usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b8(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b8_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    7usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -828,28 +764,20 @@ impl A {
     }
     #[inline]
     pub fn b9(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<8usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b9(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b9_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    8usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -866,28 +794,20 @@ impl A {
     }
     #[inline]
     pub fn b10(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<9usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b10(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b10_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    9usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1013,28 +933,20 @@ const _: () = {
 impl B {
     #[inline]
     pub fn foo(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 31u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 31u8>() as u32 as _
     }
     #[inline]
     pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 31u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 31u8>(val as u64)
     }
     #[inline]
     pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    31u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 31u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1051,28 +963,20 @@ impl B {
     }
     #[inline]
     pub fn bar(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<31usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    31usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1129,28 +1033,20 @@ const _: () = {
 impl C {
     #[inline]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1167,28 +1063,20 @@ impl C {
     }
     #[inline]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1243,28 +1131,20 @@ const _: () = {
 impl Date1 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
     }
     #[inline]
     pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    0usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1281,28 +1161,20 @@ impl Date1 {
     }
     #[inline]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
-        }
+        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    3usize,
-                    6u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1319,28 +1191,20 @@ impl Date1 {
     }
     #[inline]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
-        }
+        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    9usize,
-                    5u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1357,28 +1221,20 @@ impl Date1 {
     }
     #[inline]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
-        }
+        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
     }
     #[inline]
     pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    16usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1450,28 +1306,20 @@ const _: () = {
 impl Date2 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
     }
     #[inline]
     pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1488,28 +1336,20 @@ impl Date2 {
     }
     #[inline]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
-        }
+        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    3usize,
-                    6u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1526,28 +1366,20 @@ impl Date2 {
     }
     #[inline]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
-        }
+        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    9usize,
-                    5u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1564,28 +1396,20 @@ impl Date2 {
     }
     #[inline]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
-        }
+        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
     }
     #[inline]
     pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    16usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1602,28 +1426,20 @@ impl Date2 {
     }
     #[inline]
     pub fn byte(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u8)
-        }
+        self._bitfield_1.get_const::<24usize, 8u8>() as u8 as _
     }
     #[inline]
     pub fn set_byte(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn byte_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    24usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1706,28 +1522,20 @@ const _: () = {
 impl Date3 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
     }
     #[inline]
     pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    0usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1744,28 +1552,20 @@ impl Date3 {
     }
     #[inline]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
-        }
+        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    3usize,
-                    6u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1782,28 +1582,20 @@ impl Date3 {
     }
     #[inline]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
-        }
+        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
     }
     #[inline]
     pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    9usize,
-                    5u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1820,28 +1612,20 @@ impl Date3 {
     }
     #[inline]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
-        }
+        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
     }
     #[inline]
     pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    16usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -544,10 +544,8 @@ impl TaggedPtr {
     }
     #[inline]
     pub fn set_tag(&mut self, val: MyEnum) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 2u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn tag_raw(this: *const Self) -> MyEnum {
@@ -576,28 +574,20 @@ impl TaggedPtr {
     }
     #[inline]
     pub fn ptr(&self) -> ::std::os::raw::c_long {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 62u8>() as u64)
-        }
+        self._bitfield_1.get_const::<2usize, 62u8>() as u64 as _
     }
     #[inline]
     pub fn set_ptr(&mut self, val: ::std::os::raw::c_long) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<2usize, 62u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<2usize, 62u8>(val as u64)
     }
     #[inline]
     pub unsafe fn ptr_raw(this: *const Self) -> ::std::os::raw::c_long {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    2usize,
-                    62u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<2usize, 62u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -524,28 +524,20 @@ const _: () = {
 impl mach_msg_type_descriptor_t {
     #[inline]
     pub fn pad3(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 24u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 24u8>() as u32 as _
     }
     #[inline]
     pub fn set_pad3(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 24u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 24u8>(val as u64)
     }
     #[inline]
     pub unsafe fn pad3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    24u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 24u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -562,28 +554,20 @@ impl mach_msg_type_descriptor_t {
     }
     #[inline]
     pub fn type_(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u32)
-        }
+        self._bitfield_1.get_const::<24usize, 8u8>() as u32 as _
     }
     #[inline]
     pub fn set_type(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn type__raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    24usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
@@ -537,28 +537,20 @@ impl Default for A {
 impl A {
     #[inline]
     pub fn firmness(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_firmness(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn firmness_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -575,28 +567,20 @@ impl A {
     }
     #[inline]
     pub fn color(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u8)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_color(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn color_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -613,28 +597,20 @@ impl A {
     }
     #[inline]
     pub fn weedsBonus(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 3u8>() as u16)
-        }
+        self._bitfield_1.get_const::<8usize, 3u8>() as u16 as _
     }
     #[inline]
     pub fn set_weedsBonus(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<8usize, 3u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<8usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn weedsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    8usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<8usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -651,28 +627,20 @@ impl A {
     }
     #[inline]
     pub fn pestsBonus(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 3u8>() as u16)
-        }
+        self._bitfield_1.get_const::<11usize, 3u8>() as u16 as _
     }
     #[inline]
     pub fn set_pestsBonus(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<11usize, 3u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<11usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn pestsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    11usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<11usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -689,28 +657,20 @@ impl A {
     }
     #[inline]
     pub fn size(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 10u8>() as u16)
-        }
+        self._bitfield_1.get_const::<14usize, 10u8>() as u16 as _
     }
     #[inline]
     pub fn set_size(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<14usize, 10u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<14usize, 10u8>(val as u64)
     }
     #[inline]
     pub unsafe fn size_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    14usize,
-                    10u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<14usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -778,28 +738,20 @@ impl A {
     }
     #[inline]
     pub fn minYield(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 4u8>() as u8)
-        }
+        self._bitfield_2.get_const::<0usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_minYield(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn minYield_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 as _
         }
     }
     #[inline]
@@ -816,28 +768,20 @@ impl A {
     }
     #[inline]
     pub fn waterBonus(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<4usize, 4u8>() as u8)
-        }
+        self._bitfield_2.get_const::<4usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_waterBonus(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn waterBonus_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -519,28 +519,20 @@ const _: () = {
 impl Struct {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -557,28 +549,20 @@ impl Struct {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -595,28 +579,20 @@ impl Struct {
     }
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 6u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 6u8>() as u8 as _
     }
     #[inline]
     pub fn set_c(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 6u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 6u8>(val as u64)
     }
     #[inline]
     pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    2usize,
-                    6u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<2usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -633,28 +609,20 @@ impl Struct {
     }
     #[inline]
     pub fn d(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 16u8>() as u16)
-        }
+        self._bitfield_1.get_const::<8usize, 16u8>() as u16 as _
     }
     #[inline]
     pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<8usize, 16u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<8usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    8usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<8usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -671,28 +639,20 @@ impl Struct {
     }
     #[inline]
     pub fn e(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u8)
-        }
+        self._bitfield_1.get_const::<24usize, 8u8>() as u8 as _
     }
     #[inline]
     pub fn set_e(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    24usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -773,28 +733,20 @@ const _: () = {
 impl Inner {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 16u8>() as u16 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -811,28 +763,20 @@ impl Inner {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 16u8>() as u16)
-        }
+        self._bitfield_1.get_const::<16usize, 16u8>() as u16 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<16usize, 16u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<16usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    16usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<16usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
@@ -19,28 +19,20 @@ const _: () = {
 impl C {
     #[inline]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -57,28 +49,20 @@ impl C {
     }
     #[inline]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -520,28 +520,20 @@ pub struct Color {
 impl Color {
     #[inline]
     pub(crate) fn r(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub(crate) fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub(crate) unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -558,28 +550,20 @@ impl Color {
     }
     #[inline]
     pub(crate) fn g(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub(crate) fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub(crate) unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -596,28 +580,20 @@ impl Color {
     }
     #[inline]
     pub(crate) fn b(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
     }
     #[inline]
     pub(crate) fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub(crate) unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -520,28 +520,20 @@ pub struct Color {
 impl Color {
     #[inline]
     fn r(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -558,28 +550,20 @@ impl Color {
     }
     #[inline]
     fn g(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -596,28 +580,20 @@ impl Color {
     }
     #[inline]
     fn b(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
     }
     #[inline]
     fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -520,28 +520,20 @@ pub struct Color {
 impl Color {
     #[inline]
     pub fn r(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -558,28 +550,20 @@ impl Color {
     }
     #[inline]
     pub fn g(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -596,28 +580,20 @@ impl Color {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -546,30 +546,22 @@ impl Default for Foo {
 impl Foo {
     #[inline]
     pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 3u8>() as u8 as _
     }
     #[inline]
     pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn type__bindgen_bitfield_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
@@ -530,28 +530,20 @@ impl Default for C {
 impl C {
     #[inline]
     pub fn a(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_a(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]
@@ -568,28 +560,20 @@ impl C {
     }
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -533,28 +533,20 @@ impl Default for C {
 impl C {
     #[inline]
     pub fn a(&self) -> bool {
-        unsafe {
-            ::core::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_a(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            ::core::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::core::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::core::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]
@@ -571,28 +563,20 @@ impl C {
     }
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::core::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::core::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    7u8,
-                >(::core::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 7u8>(::core::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -530,28 +530,20 @@ impl Default for C {
 impl C {
     #[inline]
     pub fn a(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_a(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]
@@ -568,28 +560,20 @@ impl C {
     }
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -530,28 +530,20 @@ impl Default for C {
 impl C {
     #[inline]
     pub fn a(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_a(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]
@@ -568,28 +560,20 @@ impl C {
     }
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/field-rename-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-rename-callback.rs
@@ -532,30 +532,22 @@ const _: () = {
 impl RenameMe {
     #[inline]
     pub fn bitfield_less_ugly_name(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bitfield_less_ugly_name(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bitfield_less_ugly_name_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -575,28 +567,20 @@ impl RenameMe {
     }
     #[inline]
     pub fn bitfield_better_name(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bitfield_better_name(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bitfield_better_name_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -526,28 +526,20 @@ const _: () = {
 impl my_struct {
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -564,28 +556,20 @@ impl my_struct {
     }
     #[inline]
     fn private_d(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     fn set_private_d(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     unsafe fn private_d_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -521,28 +521,20 @@ const _: () = {
 impl my_struct1 {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -586,28 +578,20 @@ const _: () = {
 impl my_struct2 {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -560,28 +560,20 @@ impl Default for foo {
 impl foo {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_char {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_char) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -529,28 +529,20 @@ const _: () = {
 impl V56AMDY {
     #[inline]
     pub fn MADZ(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 10u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 10u8>() as u16 as _
     }
     #[inline]
     pub fn set_MADZ(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 10u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 10u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MADZ_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    10u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -567,28 +559,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MAI0(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 2u8>() as u16)
-        }
+        self._bitfield_1.get_const::<10usize, 2u8>() as u16 as _
     }
     #[inline]
     pub fn set_MAI0(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<10usize, 2u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<10usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MAI0_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    10usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<10usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -605,28 +589,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MAI1(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 2u8>() as u16)
-        }
+        self._bitfield_1.get_const::<12usize, 2u8>() as u16 as _
     }
     #[inline]
     pub fn set_MAI1(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<12usize, 2u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<12usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MAI1_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    12usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<12usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -643,28 +619,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MAI2(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 2u8>() as u16)
-        }
+        self._bitfield_1.get_const::<14usize, 2u8>() as u16 as _
     }
     #[inline]
     pub fn set_MAI2(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<14usize, 2u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<14usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MAI2_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    14usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<14usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -723,28 +691,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MATH(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 10u8>() as u16)
-        }
+        self._bitfield_2.get_const::<0usize, 10u8>() as u16 as _
     }
     #[inline]
     pub fn set_MATH(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_2.set_const::<0usize, 10u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_2.set_const::<0usize, 10u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MATH_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    0usize,
-                    10u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<0usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u16 as _
         }
     }
     #[inline]
@@ -761,28 +721,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MATE(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<10usize, 4u8>() as u16)
-        }
+        self._bitfield_2.get_const::<10usize, 4u8>() as u16 as _
     }
     #[inline]
     pub fn set_MATE(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_2.set_const::<10usize, 4u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_2.set_const::<10usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MATE_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    10usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<10usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u16 as _
         }
     }
     #[inline]
@@ -799,28 +751,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MATW(&self) -> U16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<14usize, 2u8>() as u16)
-        }
+        self._bitfield_2.get_const::<14usize, 2u8>() as u16 as _
     }
     #[inline]
     pub fn set_MATW(&mut self, val: U16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_2.set_const::<14usize, 2u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_2.set_const::<14usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MATW_raw(this: *const Self) -> U16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    14usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<14usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u16 as _
         }
     }
     #[inline]
@@ -837,28 +781,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MASW(&self) -> U8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<16usize, 4u8>() as u8)
-        }
+        self._bitfield_2.get_const::<16usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_MASW(&mut self, val: U8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<16usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<16usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MASW_raw(this: *const Self) -> U8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    16usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<16usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 as _
         }
     }
     #[inline]
@@ -875,28 +811,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MABW(&self) -> U8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<20usize, 3u8>() as u8)
-        }
+        self._bitfield_2.get_const::<20usize, 3u8>() as u8 as _
     }
     #[inline]
     pub fn set_MABW(&mut self, val: U8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<20usize, 3u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<20usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MABW_raw(this: *const Self) -> U8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    20usize,
-                    3u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<20usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 as _
         }
     }
     #[inline]
@@ -913,28 +841,20 @@ impl V56AMDY {
     }
     #[inline]
     pub fn MAXN(&self) -> U8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<23usize, 1u8>() as u8)
-        }
+        self._bitfield_2.get_const::<23usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_MAXN(&mut self, val: U8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<23usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<23usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn MAXN_raw(this: *const Self) -> U8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    23usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -521,28 +521,20 @@ const _: () = {
 impl Foo {
     #[inline]
     pub fn m_bitfield(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 64u8>() as u64)
-        }
+        self._bitfield_1.get_const::<0usize, 64u8>() as u64 as _
     }
     #[inline]
     pub fn set_m_bitfield(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<0usize, 64u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<0usize, 64u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m_bitfield_raw(this: *const Self) -> ::std::os::raw::c_ulong {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    0usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 32usize],
+            >>::raw_get_const::<0usize, 64u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -559,28 +551,20 @@ impl Foo {
     }
     #[inline]
     pub fn m_bar(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<64usize, 64u8>() as u64)
-        }
+        self._bitfield_1.get_const::<64usize, 64u8>() as u64 as _
     }
     #[inline]
     pub fn set_m_bar(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<64usize, 64u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<64usize, 64u8>(val as u64)
     }
     #[inline]
     pub unsafe fn m_bar_raw(this: *const Self) -> ::std::os::raw::c_ulong {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    64usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 32usize],
+            >>::raw_get_const::<64usize, 64u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -597,28 +581,20 @@ impl Foo {
     }
     #[inline]
     pub fn foo(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<128usize, 1u8>() as u64)
-        }
+        self._bitfield_1.get_const::<128usize, 1u8>() as u64 as _
     }
     #[inline]
     pub fn set_foo(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<128usize, 1u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<128usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_ulong {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    128usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 32usize],
+            >>::raw_get_const::<128usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -635,28 +611,22 @@ impl Foo {
     }
     #[inline]
     pub fn bar(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<192usize, 64u8>() as u64)
-        }
+        self._bitfield_1.get_const::<192usize, 64u8>() as u64 as _
     }
     #[inline]
     pub fn set_bar(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<192usize, 64u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<192usize, 64u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_ulong {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    192usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 32usize],
+            >>::raw_get_const::<
+                192usize,
+                64u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/issue-743.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-743.rs
@@ -533,28 +533,20 @@ impl Default for S {
 impl S {
     #[inline]
     pub fn u(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 16u8>() as u32 as _
     }
     #[inline]
     pub fn set_u(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn u_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -520,28 +520,20 @@ const _: () = {
 impl capabilities {
     #[inline]
     pub fn bit_1(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_1(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -558,28 +550,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_2(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_2(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -596,28 +580,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_3(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_3(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -634,28 +610,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_4(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<3usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_4(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_4_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    3usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -672,28 +640,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_5(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_5(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_5_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    4usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -710,28 +670,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_6(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<5usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_6(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_6_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    5usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -748,28 +700,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_7(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<6usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_7(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_7_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    6usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -786,28 +730,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_8(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<7usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_8(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_8_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    7usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -824,28 +760,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_9(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<8usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_9(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_9_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    8usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -862,28 +790,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_10(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<9usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_10(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_10_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    9usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -900,28 +820,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_11(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<10usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_11(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_11_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    10usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<10usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -938,28 +850,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_12(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<11usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_12(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_12_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    11usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<11usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -976,28 +880,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_13(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<12usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_13(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_13_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    12usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<12usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1014,28 +910,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_14(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<13usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<13usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_14(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_14_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    13usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<13usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1052,28 +940,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_15(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<14usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_15(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_15_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    14usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<14usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1090,28 +970,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_16(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<15usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<15usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_16(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_16_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    15usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<15usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1128,28 +1000,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_17(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<16usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_17(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_17_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    16usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<16usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1166,28 +1030,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_18(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<17usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<17usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_18(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_18_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    17usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<17usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1204,28 +1060,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_19(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<18usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<18usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_19(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_19_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    18usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<18usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1242,28 +1090,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_20(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<19usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<19usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_20(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_20_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    19usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<19usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1280,28 +1120,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_21(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<20usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_21(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_21_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    20usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<20usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1318,28 +1150,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_22(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<21usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<21usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_22(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_22_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    21usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<21usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1356,28 +1180,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_23(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<22usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<22usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_23(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_23_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    22usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<22usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1394,28 +1210,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_24(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<23usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<23usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_24(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_24_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    23usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1432,28 +1240,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_25(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<24usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_25(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_25_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    24usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<24usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1470,28 +1270,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_26(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<25usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<25usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_26(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_26_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    25usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<25usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1508,28 +1300,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_27(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<26usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<26usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_27(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_27_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    26usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<26usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1546,28 +1330,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_28(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<27usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<27usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_28(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_28_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    27usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<27usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1584,28 +1360,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_29(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<28usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<28usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_29(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_29_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    28usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<28usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1622,28 +1390,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_30(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<29usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<29usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_30(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_30_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    29usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<29usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1660,28 +1420,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_31(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<30usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<30usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_31(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_31_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    30usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<30usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1698,28 +1450,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_32(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<31usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_32(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_32_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    31usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1736,28 +1480,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_33(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<32usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_33(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_33_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    32usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<32usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1774,28 +1510,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_34(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<33usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<33usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_34(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<33usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<33usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_34_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    33usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<33usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1812,28 +1540,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_35(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<34usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<34usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_35(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<34usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<34usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_35_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    34usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<34usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1850,28 +1570,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_36(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<35usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<35usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_36(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<35usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<35usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_36_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    35usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<35usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1888,28 +1600,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_37(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<36usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<36usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_37(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<36usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<36usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_37_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    36usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<36usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1926,28 +1630,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_38(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<37usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<37usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_38(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<37usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<37usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_38_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    37usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<37usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1964,28 +1660,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_39(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<38usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<38usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_39(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<38usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<38usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_39_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    38usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<38usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -2002,28 +1690,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_40(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<39usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<39usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_40(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<39usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<39usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_40_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    39usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<39usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -2040,28 +1720,20 @@ impl capabilities {
     }
     #[inline]
     pub fn bit_41(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<40usize, 1u8>() as u32)
-        }
+        self._bitfield_1.get_const::<40usize, 1u8>() as u32 as _
     }
     #[inline]
     pub fn set_bit_41(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<40usize, 1u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<40usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bit_41_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 16usize],
-                >>::raw_get_const::<
-                    40usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 16usize],
+            >>::raw_get_const::<40usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -630,28 +630,20 @@ impl Default for jsval_layout__bindgen_ty_1 {
 impl jsval_layout__bindgen_ty_1 {
     #[inline]
     pub fn payload47(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 47u8>() as u64)
-        }
+        self._bitfield_1.get_const::<0usize, 47u8>() as u64 as _
     }
     #[inline]
     pub fn set_payload47(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<0usize, 47u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<0usize, 47u8>(val as u64)
     }
     #[inline]
     pub unsafe fn payload47_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    0usize,
-                    47u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<0usize, 47u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -674,10 +666,8 @@ impl jsval_layout__bindgen_ty_1 {
     }
     #[inline]
     pub fn set_tag(&mut self, val: JSValueTag) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<47usize, 17u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<47usize, 17u8>(val as u64)
     }
     #[inline]
     pub unsafe fn tag_raw(this: *const Self) -> JSValueTag {

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -599,28 +599,20 @@ const _: () = {
 impl rte_eth_link {
     #[inline]
     pub fn link_duplex(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_link_duplex(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn link_duplex_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -637,28 +629,20 @@ impl rte_eth_link {
     }
     #[inline]
     pub fn link_autoneg(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_link_autoneg(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn link_autoneg_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -675,28 +659,20 @@ impl rte_eth_link {
     }
     #[inline]
     pub fn link_status(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_link_status(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn link_status_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -598,28 +598,20 @@ impl Default for rte_eth_rxmode {
 impl rte_eth_rxmode {
     #[inline]
     pub fn header_split(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_header_split(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn header_split_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -636,28 +628,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn hw_ip_checksum(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_hw_ip_checksum(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_ip_checksum_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -674,28 +658,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn hw_vlan_filter(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_hw_vlan_filter(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_filter_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -712,28 +688,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn hw_vlan_strip(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<3usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_hw_vlan_strip(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_strip_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    3usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -750,28 +718,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn hw_vlan_extend(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<4usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_hw_vlan_extend(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_extend_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    4usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -788,28 +748,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn jumbo_frame(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<5usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_jumbo_frame(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn jumbo_frame_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    5usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -826,28 +778,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn hw_strip_crc(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<6usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_hw_strip_crc(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_strip_crc_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    6usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -864,28 +808,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn enable_scatter(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<7usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_enable_scatter(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn enable_scatter_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    7usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -902,28 +838,20 @@ impl rte_eth_rxmode {
     }
     #[inline]
     pub fn enable_lro(&self) -> u16 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<8usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_enable_lro(&mut self, val: u16) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn enable_lro_raw(this: *const Self) -> u16 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    8usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -1073,28 +1001,20 @@ impl Default for rte_eth_txmode {
 impl rte_eth_txmode {
     #[inline]
     pub fn hw_vlan_reject_tagged(&self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_hw_vlan_reject_tagged(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_reject_tagged_raw(this: *const Self) -> u8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1111,28 +1031,20 @@ impl rte_eth_txmode {
     }
     #[inline]
     pub fn hw_vlan_reject_untagged(&self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_hw_vlan_reject_untagged(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_reject_untagged_raw(this: *const Self) -> u8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -1149,28 +1061,20 @@ impl rte_eth_txmode {
     }
     #[inline]
     pub fn hw_vlan_insert_pvid(&self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_hw_vlan_insert_pvid(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn hw_vlan_insert_pvid_raw(this: *const Self) -> u8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -637,28 +637,20 @@ const _: () = {
 impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     #[inline]
     pub fn l2_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_l2_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l2_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -675,28 +667,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn l3_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_l3_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l3_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -713,28 +697,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn l4_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<8usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_l4_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l4_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    8usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<8usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -751,28 +727,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn tun_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<12usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_tun_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<12usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<12usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn tun_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    12usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<12usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -789,28 +757,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn inner_l2_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<16usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_inner_l2_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<16usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<16usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn inner_l2_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    16usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<16usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -827,28 +787,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn inner_l3_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<20usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_inner_l3_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<20usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<20usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn inner_l3_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    20usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<20usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -865,28 +817,20 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     }
     #[inline]
     pub fn inner_l4_type(&self) -> u32 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<24usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_inner_l4_type(&mut self, val: u32) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<24usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<24usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn inner_l4_type_raw(this: *const Self) -> u32 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    24usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<24usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1199,28 +1143,20 @@ const _: () = {
 impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     #[inline]
     pub fn l2_len(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 7u8>() as u64)
-        }
+        self._bitfield_1.get_const::<0usize, 7u8>() as u64 as _
     }
     #[inline]
     pub fn set_l2_len(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l2_len_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    0usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<0usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -1237,28 +1173,20 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     }
     #[inline]
     pub fn l3_len(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 9u8>() as u64)
-        }
+        self._bitfield_1.get_const::<7usize, 9u8>() as u64 as _
     }
     #[inline]
     pub fn set_l3_len(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<7usize, 9u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<7usize, 9u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l3_len_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    7usize,
-                    9u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<7usize, 9u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -1275,28 +1203,20 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     }
     #[inline]
     pub fn l4_len(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u64)
-        }
+        self._bitfield_1.get_const::<16usize, 8u8>() as u64 as _
     }
     #[inline]
     pub fn set_l4_len(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
     }
     #[inline]
     pub unsafe fn l4_len_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    16usize,
-                    8u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -1313,28 +1233,20 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     }
     #[inline]
     pub fn tso_segsz(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 16u8>() as u64)
-        }
+        self._bitfield_1.get_const::<24usize, 16u8>() as u64 as _
     }
     #[inline]
     pub fn set_tso_segsz(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<24usize, 16u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<24usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn tso_segsz_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    24usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<24usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -1351,28 +1263,20 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     }
     #[inline]
     pub fn outer_l3_len(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<40usize, 9u8>() as u64)
-        }
+        self._bitfield_1.get_const::<40usize, 9u8>() as u64 as _
     }
     #[inline]
     pub fn set_outer_l3_len(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<40usize, 9u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<40usize, 9u8>(val as u64)
     }
     #[inline]
     pub unsafe fn outer_l3_len_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    40usize,
-                    9u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<40usize, 9u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]
@@ -1389,28 +1293,20 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     }
     #[inline]
     pub fn outer_l2_len(&self) -> u64 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<49usize, 7u8>() as u64)
-        }
+        self._bitfield_1.get_const::<49usize, 7u8>() as u64 as _
     }
     #[inline]
     pub fn set_outer_l2_len(&mut self, val: u64) {
-        unsafe {
-            let val: u64 = val as _;
-            self._bitfield_1.set_const::<49usize, 7u8>(val as u64)
-        }
+        let val: u64 = val as _;
+        self._bitfield_1.set_const::<49usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn outer_l2_len_raw(this: *const Self) -> u64 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 7usize],
-                >>::raw_get_const::<
-                    49usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 7usize],
+            >>::raw_get_const::<49usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u64 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -519,28 +519,20 @@ const _: () = {
 impl C {
     #[inline]
     pub fn a(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_a(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]
@@ -557,28 +549,20 @@ impl C {
     }
     #[inline]
     pub fn b(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
     }
     #[inline]
     pub fn set_b(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -519,28 +519,20 @@ const _: () = {
 impl Date {
     #[inline]
     pub fn day(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 5u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 5u8>() as u8 as _
     }
     #[inline]
     pub fn set_day(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 5u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 5u8>(val as u64)
     }
     #[inline]
     pub unsafe fn day_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    0usize,
-                    5u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<0usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -557,28 +549,20 @@ impl Date {
     }
     #[inline]
     pub fn month(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 4u8>() as u8)
-        }
+        self._bitfield_1.get_const::<5usize, 4u8>() as u8 as _
     }
     #[inline]
     pub fn set_month(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<5usize, 4u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<5usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn month_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    5usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<5usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -595,28 +579,20 @@ impl Date {
     }
     #[inline]
     pub fn year(&self) -> ::std::os::raw::c_short {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 15u8>() as u16)
-        }
+        self._bitfield_1.get_const::<9usize, 15u8>() as u16 as _
     }
     #[inline]
     pub fn set_year(&mut self, val: ::std::os::raw::c_short) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<9usize, 15u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<9usize, 15u8>(val as u64)
     }
     #[inline]
     pub unsafe fn year_raw(this: *const Self) -> ::std::os::raw::c_short {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 3usize],
-                >>::raw_get_const::<
-                    9usize,
-                    15u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_get_const::<9usize, 15u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -536,28 +536,20 @@ const _: () = {
 impl PrivateBitFields {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
     }
     #[inline]
     fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -574,28 +566,20 @@ impl PrivateBitFields {
     }
     #[inline]
     fn b(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
     }
     #[inline]
     fn set_b(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -650,28 +634,20 @@ const _: () = {
 impl PublicBitFields {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -688,28 +664,20 @@ impl PublicBitFields {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -764,28 +732,20 @@ const _: () = {
 impl MixedBitFields {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
     }
     #[inline]
     fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -802,28 +762,20 @@ impl MixedBitFields {
     }
     #[inline]
     pub fn d(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_d(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1008,28 +960,20 @@ const _: () = {
 impl Override {
     #[inline]
     pub fn bf_a(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
     }
     #[inline]
     pub fn set_bf_a(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bf_a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    0usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1046,28 +990,20 @@ impl Override {
     }
     #[inline]
     fn bf_b(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
     }
     #[inline]
     fn set_bf_b(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
     }
     #[inline]
     unsafe fn bf_b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    4usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -1084,28 +1020,20 @@ impl Override {
     }
     #[inline]
     fn private_bf_c(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 4u8>() as u32)
-        }
+        self._bitfield_1.get_const::<8usize, 4u8>() as u32 as _
     }
     #[inline]
     fn set_private_bf_c(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
     }
     #[inline]
     unsafe fn private_bf_c_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    8usize,
-                    4u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<8usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
+++ b/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
@@ -552,28 +552,20 @@ const _: () = {
 impl redundant_packed_bitfield {
     #[inline]
     pub fn b0(&self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_b0(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b0_raw(this: *const Self) -> u8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]
@@ -590,28 +582,20 @@ impl redundant_packed_bitfield {
     }
     #[inline]
     pub fn b1(&self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
     }
     #[inline]
     pub fn set_b1(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b1_raw(this: *const Self) -> u8 {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -522,28 +522,20 @@ const _: () = {
 impl bitfield {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -560,28 +552,20 @@ impl bitfield {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    1usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -598,28 +582,20 @@ impl bitfield {
     }
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
-        }
+        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
     }
     #[inline]
     pub fn set_c(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    2usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -636,28 +612,20 @@ impl bitfield {
     }
     #[inline]
     pub fn d(&self) -> ::std::os::raw::c_ushort {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 2u8>() as u16)
-        }
+        self._bitfield_1.get_const::<6usize, 2u8>() as u16 as _
     }
     #[inline]
     pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
-        unsafe {
-            let val: u16 = val as _;
-            self._bitfield_1.set_const::<6usize, 2u8>(val as u64)
-        }
+        let val: u16 = val as _;
+        self._bitfield_1.set_const::<6usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    6usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<6usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u16 as _
         }
     }
     #[inline]
@@ -716,28 +684,20 @@ impl bitfield {
     }
     #[inline]
     pub fn f(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 2u8>() as u32)
-        }
+        self._bitfield_2.get_const::<0usize, 2u8>() as u32 as _
     }
     #[inline]
     pub fn set_f(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_2.set_const::<0usize, 2u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_2.set_const::<0usize, 2u8>(val as u64)
     }
     #[inline]
     pub unsafe fn f_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    0usize,
-                    2u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<0usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u32 as _
         }
     }
     #[inline]
@@ -754,28 +714,20 @@ impl bitfield {
     }
     #[inline]
     pub fn g(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<32usize, 32u8>() as u32)
-        }
+        self._bitfield_2.get_const::<32usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_g(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_2.set_const::<32usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_2.set_const::<32usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 8usize],
-                >>::raw_get_const::<
-                    32usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 8usize],
+            >>::raw_get_const::<32usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -553,28 +553,20 @@ impl Default for timex_named {
 impl timex_named {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    0usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<0usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -591,28 +583,20 @@ impl timex_named {
     }
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<32usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<32usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<32usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    32usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<32usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -629,28 +613,20 @@ impl timex_named {
     }
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<64usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<64usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<64usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<64usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    64usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<64usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -667,28 +643,20 @@ impl timex_named {
     }
     #[inline]
     pub fn d(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<96usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<96usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_d(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<96usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<96usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    96usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<96usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -705,28 +673,22 @@ impl timex_named {
     }
     #[inline]
     pub fn e(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<128usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<128usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_e(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<128usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<128usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    128usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                128usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -743,28 +705,22 @@ impl timex_named {
     }
     #[inline]
     pub fn f(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<160usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<160usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_f(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<160usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<160usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn f_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    160usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                160usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -781,28 +737,22 @@ impl timex_named {
     }
     #[inline]
     pub fn g(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<192usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<192usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_g(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<192usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<192usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    192usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                192usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -819,28 +769,22 @@ impl timex_named {
     }
     #[inline]
     pub fn h(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<224usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<224usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_h(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<224usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<224usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn h_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    224usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                224usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -857,28 +801,22 @@ impl timex_named {
     }
     #[inline]
     pub fn i(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<256usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<256usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_i(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<256usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<256usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn i_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    256usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                256usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -895,28 +833,22 @@ impl timex_named {
     }
     #[inline]
     pub fn j(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<288usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<288usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_j(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<288usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<288usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn j_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    288usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                288usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]
@@ -933,28 +865,22 @@ impl timex_named {
     }
     #[inline]
     pub fn k(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<320usize, 32u8>() as u32)
-        }
+        self._bitfield_1.get_const::<320usize, 32u8>() as u32 as _
     }
     #[inline]
     pub fn set_k(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<320usize, 32u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<320usize, 32u8>(val as u64)
     }
     #[inline]
     pub unsafe fn k_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 44usize],
-                >>::raw_get_const::<
-                    320usize,
-                    32u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 44usize],
+            >>::raw_get_const::<
+                320usize,
+                32u8,
+            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -529,9 +529,7 @@ impl Default for U4 {
 impl U4 {
     #[inline]
     pub fn derp(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
-        }
+        unsafe { self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _ }
     }
     #[inline]
     pub fn set_derp(&mut self, val: ::std::os::raw::c_uint) {
@@ -543,14 +541,10 @@ impl U4 {
     #[inline]
     pub unsafe fn derp_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -604,9 +598,7 @@ impl Default for B {
 impl B {
     #[inline]
     pub fn foo(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 31u8>() as u32)
-        }
+        unsafe { self._bitfield_1.get_const::<0usize, 31u8>() as u32 as _ }
     }
     #[inline]
     pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
@@ -618,14 +610,10 @@ impl B {
     #[inline]
     pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    31u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 31u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -642,9 +630,7 @@ impl B {
     }
     #[inline]
     pub fn bar(&self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
-        }
+        unsafe { self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _ }
     }
     #[inline]
     pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
@@ -656,14 +642,10 @@ impl B {
     #[inline]
     pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get_const::<
-                    0usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u8 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -528,28 +528,20 @@ const _: () = {
 impl foo__bindgen_ty_1 {
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 7u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 7u8>() as u32 as _
     }
     #[inline]
     pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
     }
     #[inline]
     pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    7u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -566,28 +558,20 @@ impl foo__bindgen_ty_1 {
     }
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 25u8>() as u32)
-        }
+        self._bitfield_1.get_const::<7usize, 25u8>() as u32 as _
     }
     #[inline]
     pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<7usize, 25u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<7usize, 25u8>(val as u64)
     }
     #[inline]
     pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    7usize,
-                    25u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<7usize, 25u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -585,28 +585,20 @@ impl Default for Weird {
 impl Weird {
     #[inline]
     pub fn bitTest(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u32)
-        }
+        self._bitfield_1.get_const::<0usize, 16u8>() as u32 as _
     }
     #[inline]
     pub fn set_bitTest(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bitTest_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    0usize,
-                    16u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -623,28 +615,20 @@ impl Weird {
     }
     #[inline]
     pub fn bitTest2(&self) -> ::std::os::raw::c_uint {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 15u8>() as u32)
-        }
+        self._bitfield_1.get_const::<16usize, 15u8>() as u32 as _
     }
     #[inline]
     pub fn set_bitTest2(&mut self, val: ::std::os::raw::c_uint) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_1.set_const::<16usize, 15u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_1.set_const::<16usize, 15u8>(val as u64)
     }
     #[inline]
     pub unsafe fn bitTest2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get_const::<
-                    16usize,
-                    15u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 4usize],
+            >>::raw_get_const::<16usize, 15u8>(::std::ptr::addr_of!((*this)._bitfield_1))
+                as u32 as _
         }
     }
     #[inline]
@@ -691,10 +675,8 @@ impl Weird {
     }
     #[inline]
     pub fn set_mFillOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_2.set_const::<0usize, 3u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_2.set_const::<0usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn mFillOpacitySource_raw(this: *const Self) -> nsStyleSVGOpacitySource {
@@ -732,10 +714,8 @@ impl Weird {
     }
     #[inline]
     pub fn set_mStrokeOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
-        unsafe {
-            let val: u32 = val as _;
-            self._bitfield_2.set_const::<3usize, 3u8>(val as u64)
-        }
+        let val: u32 = val as _;
+        self._bitfield_2.set_const::<3usize, 3u8>(val as u64)
     }
     #[inline]
     pub unsafe fn mStrokeOpacitySource_raw(
@@ -769,28 +749,20 @@ impl Weird {
     }
     #[inline]
     pub fn mStrokeDasharrayFromObject(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<6usize, 1u8>() as u8)
-        }
+        self._bitfield_2.get_const::<6usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_mStrokeDasharrayFromObject(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<6usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<6usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn mStrokeDasharrayFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    6usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 != 0
         }
     }
     #[inline]
@@ -807,28 +779,20 @@ impl Weird {
     }
     #[inline]
     pub fn mStrokeDashoffsetFromObject(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<7usize, 1u8>() as u8)
-        }
+        self._bitfield_2.get_const::<7usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_mStrokeDashoffsetFromObject(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<7usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<7usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn mStrokeDashoffsetFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    7usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 != 0
         }
     }
     #[inline]
@@ -845,28 +809,20 @@ impl Weird {
     }
     #[inline]
     pub fn mStrokeWidthFromObject(&self) -> bool {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_2.get_const::<8usize, 1u8>() as u8)
-        }
+        self._bitfield_2.get_const::<8usize, 1u8>() as u8 != 0
     }
     #[inline]
     pub fn set_mStrokeWidthFromObject(&mut self, val: bool) {
-        unsafe {
-            let val: u8 = val as _;
-            self._bitfield_2.set_const::<8usize, 1u8>(val as u64)
-        }
+        let val: u8 = val as _;
+        self._bitfield_2.set_const::<8usize, 1u8>(val as u64)
     }
     #[inline]
     pub unsafe fn mStrokeWidthFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 2usize],
-                >>::raw_get_const::<
-                    8usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
-            )
+            <__BindgenBitfieldUnit<
+                [u8; 2usize],
+            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
+                as u8 != 0
         }
     }
     #[inline]

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2047,6 +2047,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
 
         let bitfield_ty_item = ctx.resolve_item(self.ty());
         let bitfield_ty = bitfield_ty_item.expect_type();
+        let bitfield_ty_kind = bitfield_ty.canonical_type(ctx).kind();
         let bitfield_ty_ident = bitfield_ty.name();
 
         let bitfield_ty_layout = bitfield_ty
@@ -2132,36 +2133,61 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 }
             }));
         } else {
+            let is_rust_union =
+                parent.is_union() && struct_layout.is_rust_union();
+
+            let get = quote! { self.#unit_field_ident.get_const::<#offset, #width>() as #bitfield_int_ty };
+            let raw_get = quote! {
+                <#unit_field_ty>::raw_get_const::<#offset, #width>(
+                    ::#prefix::ptr::addr_of!((*this).#unit_field_ident),
+                ) as #bitfield_int_ty
+            };
+
+            let (getter_inner, raw_getter_inner) = match bitfield_ty_kind {
+                TypeKind::Int(IntKind::Bool) => {
+                    (quote! { #get != 0 }, quote! { #raw_get != 0 })
+                }
+                TypeKind::Enum(..) => (
+                    quote! { ::#prefix::mem::transmute(#get) },
+                    quote! { ::#prefix::mem::transmute(#raw_get) },
+                ),
+                _ => (quote! { #get as _ }, quote! { #raw_get as _ }),
+            };
+
+            let getter_body = if is_rust_union ||
+                matches!(bitfield_ty_kind, TypeKind::Enum(..))
+            {
+                quote! { unsafe { #getter_inner } }
+            } else {
+                getter_inner
+            };
+
+            let setter_inner = quote! {
+                let val: #bitfield_int_ty = val as _;
+                self.#unit_field_ident.set_const::<#offset, #width>(val as u64)
+            };
+            let setter_body = if is_rust_union {
+                quote! { unsafe { #setter_inner } }
+            } else {
+                setter_inner
+            };
+
             methods.extend(Some(quote! {
                 #[inline]
                 #access_spec fn #getter_name(&self) -> #bitfield_ty {
-                    unsafe {
-                        ::#prefix::mem::transmute(
-                            self.#unit_field_ident.get_const::<#offset, #width>()
-                                as #bitfield_int_ty
-                        )
-                    }
+                    #getter_body
                 }
 
                 #[inline]
                 #access_spec fn #setter_name(&mut self, val: #bitfield_ty) {
-                    unsafe {
-                        let val: #bitfield_int_ty = val as _;
-                        self.#unit_field_ident.set_const::<#offset, #width>(
-                            val as u64
-                        )
-                    }
+                    #setter_body
                 }
             }));
 
             methods.extend(Some(quote! {
                 #[inline]
                 #access_spec unsafe fn #raw_getter_name(this: *const Self) -> #bitfield_ty {
-                    unsafe {
-                        ::#prefix::mem::transmute(<#unit_field_ty>::raw_get_const::<#offset, #width>(
-                            ::#prefix::ptr::addr_of!((*this).#unit_field_ident),
-                        ) as #bitfield_int_ty)
-                    }
+                    unsafe { #raw_getter_inner }
                 }
 
                 #[inline]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/2807 , Fixes https://github.com/rust-lang/rust-bindgen/issues/3355 (=https://github.com/rust-lang/rust-bindgen/issues/3241#issuecomment-3953814766)

PR https://github.com/rust-lang/rust-bindgen/pull/3335 replaced `transmute` with `as _` in the union branch getter/setter and the non-union setter, and removed the unsafe block from the union branch. It left non-union getter and raw getter, emitting `unsafe { transmute(...) }` and triggering `unnecessary_transmutes` warning for integer (https://github.com/rust-lang/rust-bindgen/issues/2807). It replaced `transmute` with `val as _` for non-union setter and kept `unsafe` block which is required for Rust unions (its field access is unsafe) but redundant for the rest of cases (https://github.com/rust-lang/rust-bindgen/issues/3355).

This PR type-dispatches the non-union getter codegen, and removes unnecessary unsafe block from the non-union setter. It dispatches on `bitfield_ty.canonical_type(ctx).kind()` instead of `bitfield_ty.kind()` to resolve `Alias`/`Elaborated` wrappers clang applies.

- integer getter: `unsafe { transmute(get_const() as u32) }` (unnecessary transmutes) -> `get_const() as u32 as _` 
- bool getter: `unsafe { transmute(get_const() as u8) }` -> `get_const() as u8 != 0`
- enum getter: unchanged. `unsafe { transmute(get_const() as u32) }`
- non-union setter on Rust unions: unchanged. `unsafe { let val: u32 = val as _; self._bitfield_1.set_const(val as u64) }`
- non-union setter for the rest of cases: removes unnecessary unsafe block for regular structs. `let val: u32 = val as _; self._bitfield_1.set_const(val as u64)`

