### PR TITLE
CI: Pin libtinfo5 to a permanent archive URL

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -108,11 +108,9 @@ jobs:
       matrix:
         platform:
           - os: ubuntu-latest
-            libtinfo: libtinfo5_6.3-2ubuntu0.1_amd64.deb
-            ubuntu_repo: https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/
+            libtinfo: libtinfo5_6.3+20220423-2ubuntu0.1_amd64.deb
           - os: ubuntu-24.04-arm
-            libtinfo: libtinfo5_6.3-2ubuntu0.1_arm64.deb
-            ubuntu_repo: https://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses/
+            libtinfo: libtinfo5_6.3+20220423-2ubuntu0.1_arm64.deb
         llvm_version: ["9.0", "16.0"]
         release_build: [0, 1]
         no_default_features: [0, 1]
@@ -126,8 +124,7 @@ jobs:
           # prevent explosion
           - platform:
               os: ubuntu-latest
-              libtinfo: libtinfo5_6.3-2ubuntu0.1_amd64.deb
-              ubuntu_repo: https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/
+              libtinfo: libtinfo5_6.3+20220423-2ubuntu0.1_amd64.deb
             llvm_version: "16.0"
             release_build: 0
             no_default_features: 0
@@ -150,7 +147,7 @@ jobs:
       - name: Install libtinfo
         if: startsWith(matrix.platform.os, 'ubuntu')
         run: |
-          wget ${{matrix.platform.ubuntu_repo}}${{matrix.platform.libtinfo}}
+          wget https://old-releases.ubuntu.com/ubuntu/pool/universe/n/ncurses/${{matrix.platform.libtinfo}}
           sudo dpkg -i ${{matrix.platform.libtinfo}}
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.5


### PR DESCRIPTION
## Background

`sudo apt-get update && sudo apt-get install libtinfo5` had been used since https://github.com/rust-lang/rust-bindgen/pull/2368 but it broke when `ubuntu-latest` was upgraded to Ubuntu 24.04 (noble) where `libtinfo5` is not available. https://github.com/rust-lang/rust-bindgen/pull/2952 fixed that by switching to `wget` + `dpkg -i`, but used a hardcoded URL pointing to the live pool mirror. The CI now fails because `libtinfo5_6.3-2ubuntu0.1_arm64.deb` no longer exists in https://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses/ and instead it was replaced with `6.3-2ubuntu0.2` on July 2.

## Alternatives

Simply bumping the version to `0.2` would fix the CI for now, but it will break again and require someone to bump the version each time. Adding a temporary jammy apt source would work until Jammy's EOL in April 2027, after which we would still need to migrate to Ubuntu snapshots or old‑releases anyway.