### PR TITLE
Restrict newtype constant wrapping to actual type aliases

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-3303-new-type-alias-default.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3303-new-type-alias-default.rs
@@ -1,0 +1,2 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const BOGUS_CONST: u32 = u32(0);

--- a/bindgen-tests/tests/expectations/tests/issue-3303-new-type-alias-default.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3303-new-type-alias-default.rs
@@ -1,2 +1,2 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-pub const BOGUS_CONST: u32 = u32(0);
+pub const BOGUS_CONST: u32 = 0;

--- a/bindgen-tests/tests/headers/issue-3303-new-type-alias-default.h
+++ b/bindgen-tests/tests/headers/issue-3303-new-type-alias-default.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --default-alias-style=new_type
+
+#define BOGUS_CONST 0x00000000

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -810,11 +810,19 @@ impl CodeGenerator for Var {
             };
 
             if let Some(mut val) = const_expr {
-                let var_ty_item = ctx.resolve_item(var_ty);
-                if matches!(
-                    var_ty_item.alias_style(ctx),
-                    AliasVariation::NewType | AliasVariation::NewTypeDeref
-                ) {
+                let var_ty_item =
+                    var_ty.into_resolver().through_type_refs().resolve(ctx);
+
+                let is_alias = var_ty_item
+                    .as_type()
+                    .is_some_and(|ty| matches!(ty.kind(), TypeKind::Alias(..)));
+
+                if is_alias &&
+                    matches!(
+                        var_ty_item.alias_style(ctx),
+                        AliasVariation::NewType | AliasVariation::NewTypeDeref
+                    )
+                {
                     val = quote! { #ty(#val) };
                 }
                 result.push(quote! {


### PR DESCRIPTION
Fixes #3303

`alias_style` helper method fall backs to `ctx.options().default_alias_style` without checking if the item is actually a typedef/alias, resulting in matching built-in primitives to new type variant. The fix uses `ItemResolver` and `.through_type_refs()` to unwrap C type qualifiers (e.g. `const`, `volatile`) and verifies that the type kind is alias.