### PR TITLE
Return `NoHeadersProvided` error when no input headers are provided

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -564,6 +564,24 @@ fn test_mixed_header_and_header_contents() {
 }
 
 #[test]
+fn test_no_header_provided() {
+    use bindgen::BindgenError;
+
+    let result = builder().generate();
+    assert_eq!(result.err(), Some(BindgenError::NoHeadersProvided));
+
+    let empty_header =
+        tempfile::Builder::new().suffix(".h").tempfile().unwrap();
+    let result = builder()
+        .header(empty_header.path().to_str().unwrap())
+        .generate();
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+
+    let result = builder().header_contents("test.h", "").generate();
+    assert!(result.is_ok(), "Expected success, got: {:?}", result.err());
+}
+
+#[test]
 fn test_macro_fallback_non_system_dir() {
     let actual = builder()
         .header(concat!(

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -313,6 +313,14 @@ fn get_extra_clang_args(
 impl Builder {
     /// Generate the Rust bindings using the options built up thus far.
     pub fn generate(mut self) -> Result<Bindings, BindgenError> {
+        // Ensure at least one input source (file or content) was provided.
+        // This does not enforce non-empty content, as header_contents always adds an entry.
+        if self.options.input_headers.is_empty() &&
+            self.options.input_header_contents.is_empty()
+        {
+            return Err(BindgenError::NoHeadersProvided);
+        }
+
         // Keep rust_features synced with rust_target
         self.options.rust_features = match self.options.rust_edition {
             Some(edition) => {
@@ -626,6 +634,8 @@ pub enum BindgenError {
     FolderAsHeader(PathBuf),
     /// Permissions to read the header is insufficient.
     InsufficientPermissions(PathBuf),
+    /// No input headers were provided.
+    NoHeadersProvided,
     /// The header does not exist.
     NotExist(PathBuf),
     /// Clang diagnosed an error.
@@ -644,6 +654,9 @@ impl std::fmt::Display for BindgenError {
             }
             BindgenError::InsufficientPermissions(h) => {
                 write!(f, "insufficient permissions to read '{}'", h.display())
+            }
+            BindgenError::NoHeadersProvided => {
+                write!(f, "no input headers were provided")
             }
             BindgenError::NotExist(h) => {
                 write!(f, "header '{}' does not exist.", h.display())


### PR DESCRIPTION
Supersede #3321
Fixes #3320