### PR TITLE
ir: Skip phantom anonymous members from inside attribute expressions

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-3295-aligned-struct-with-alignof.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3295-aligned-struct-with-alignof.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct base_t {
+    pub __bindgen_anon_1: base_t__bindgen_ty_1,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct base_t__bindgen_ty_1 {
+    pub aaa: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct base_t__bindgen_ty_1__bindgen_ty_1 {
+    pub aaa: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of base_t__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<base_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of base_t__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<base_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: base_t__bindgen_ty_1__bindgen_ty_1::aaa",
+    ][::std::mem::offset_of!(base_t__bindgen_ty_1__bindgen_ty_1, aaa) - 0usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of base_t__bindgen_ty_1",
+    ][::std::mem::size_of::<base_t__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of base_t__bindgen_ty_1",
+    ][::std::mem::align_of::<base_t__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: base_t__bindgen_ty_1::aaa",
+    ][::std::mem::offset_of!(base_t__bindgen_ty_1, aaa) - 0usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of base_t"][::std::mem::size_of::<base_t>() - 4usize];
+    ["Alignment of base_t"][::std::mem::align_of::<base_t>() - 4usize];
+};
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct mixed_t {
+    pub __bindgen_anon_1: mixed_t__bindgen_ty_1,
+    pub __bindgen_anon_2: mixed_t__bindgen_ty_2,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct mixed_t__bindgen_ty_1 {
+    pub real_field: ::std::os::raw::c_int,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct mixed_t__bindgen_ty_1__bindgen_ty_1 {
+    pub phantom: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of mixed_t__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<mixed_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of mixed_t__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<mixed_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: mixed_t__bindgen_ty_1__bindgen_ty_1::phantom",
+    ][::std::mem::offset_of!(mixed_t__bindgen_ty_1__bindgen_ty_1, phantom) - 0usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of mixed_t__bindgen_ty_1",
+    ][::std::mem::size_of::<mixed_t__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of mixed_t__bindgen_ty_1",
+    ][::std::mem::align_of::<mixed_t__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: mixed_t__bindgen_ty_1::real_field",
+    ][::std::mem::offset_of!(mixed_t__bindgen_ty_1, real_field) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct mixed_t__bindgen_ty_2 {
+    pub another_real: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of mixed_t__bindgen_ty_2",
+    ][::std::mem::size_of::<mixed_t__bindgen_ty_2>() - 4usize];
+    [
+        "Alignment of mixed_t__bindgen_ty_2",
+    ][::std::mem::align_of::<mixed_t__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: mixed_t__bindgen_ty_2::another_real",
+    ][::std::mem::offset_of!(mixed_t__bindgen_ty_2, another_real) - 0usize];
+};
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of mixed_t"][::std::mem::size_of::<mixed_t>() - 8usize];
+    ["Alignment of mixed_t"][::std::mem::align_of::<mixed_t>() - 4usize];
+};

--- a/bindgen-tests/tests/headers/issue-3295-aligned-struct-with-alignof.h
+++ b/bindgen-tests/tests/headers/issue-3295-aligned-struct-with-alignof.h
@@ -1,0 +1,30 @@
+// bindgen-flags: --rust-target=1.77
+
+// Regression test for #3295: clang exposes the anonymous struct declared
+// inside `__alignof__(...)` of an aligned attribute as a child of the
+// surrounding struct. Bindgen used to treat that child as an extra
+// anonymous member, doubling the surrounding struct's layout and
+// producing failing size assertions in the generated bindings.
+
+typedef struct base_t {
+    struct {
+        int aaa;
+    } __attribute__((aligned(
+        __alignof__(
+            struct {int aaa;}
+        )
+    )));
+} base_t;
+
+typedef struct mixed_t {
+    struct {
+        int real_field;
+    } __attribute__((aligned(
+        __alignof__(
+            struct {int phantom;}
+        )
+    )));
+    struct {
+        int another_real;
+    };
+} mixed_t;

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -389,6 +389,64 @@ impl Cursor {
         unsafe { clang_getCursorExtent(self.x) }
     }
 
+    /// Returns `true` if `other`'s source range lies fully within
+    /// `self`'s source range.
+    ///
+    /// This is useful for detecting child cursors that clang exposes
+    /// underneath a parent but whose source location is actually outside the
+    /// parent's body (e.g. anonymous types declared inside an attribute
+    /// expression on the parent).
+    pub(crate) fn extent_contains(&self, other: &Cursor) -> bool {
+        unsafe {
+            let parent_range = clang_getCursorExtent(self.x);
+            let parent_start = clang_getRangeStart(parent_range);
+            let parent_end = clang_getRangeEnd(parent_range);
+            let child_range = clang_getCursorExtent(other.x);
+            let child_start = clang_getRangeStart(child_range);
+            let child_end = clang_getRangeEnd(child_range);
+
+            let mut parent_file = mem::zeroed::<CXFile>();
+            let mut child_file = mem::zeroed::<CXFile>();
+            let mut parent_start_off: c_uint = 0;
+            let mut parent_end_off: c_uint = 0;
+            let mut child_start_off: c_uint = 0;
+            let mut child_end_off: c_uint = 0;
+
+            clang_getFileLocation(
+                parent_start,
+                &mut parent_file,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut parent_start_off,
+            );
+            clang_getFileLocation(
+                parent_end,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut parent_end_off,
+            );
+            clang_getFileLocation(
+                child_start,
+                &mut child_file,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut child_start_off,
+            );
+            clang_getFileLocation(
+                child_end,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut child_end_off,
+            );
+
+            parent_file == child_file &&
+                child_start_off >= parent_start_off &&
+                child_end_off <= parent_end_off
+        }
+    }
+
     /// Get the raw declaration comment for this referent, if one exists.
     pub(crate) fn raw_comment(&self) -> Option<String> {
         let s = unsafe {

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1477,7 +1477,20 @@ impl CompInfo {
 
                         // A declaration of an union or a struct without name
                         // could also be an unnamed field, unfortunately.
-                        if cur.is_anonymous() && cur.kind() != CXCursor_EnumDecl
+                        // However, anonymous types declared *outside* the
+                        // parent struct's body — for example an anonymous
+                        // struct that appears inside an `__alignof__`
+                        // expression on the parent's
+                        // `__attribute__((aligned(...)))` — are exposed by
+                        // clang as child cursors of the parent struct, even
+                        // though they are not real members. Skip those by
+                        // checking that the child's source range is inside
+                        // the parent's source range; otherwise we would
+                        // append a phantom field and corrupt the parent's
+                        // layout (#3295).
+                        if cur.is_anonymous() &&
+                            cur.kind() != CXCursor_EnumDecl &&
+                            cursor.extent_contains(&cur)
                         {
                             let ty = cur.cur_type();
                             let public = cur.public_accessible();


### PR DESCRIPTION
Supersede https://github.com/rust-lang/rust-bindgen/pull/3361
Fixes https://github.com/rust-lang/rust-bindgen/issues/3295

`CompInfo::from_ty` unconditionally promotes any anonymous struct or union child cursor as a member, adding phantom members to corrupt the struct's layout. Clang exposes anonymous structs declared inside `__alignof__` expressions within `__attribute__((aligned(...)))` as child cursors of the surrounding struct.

`Cursor::extent_contains` checks the cursor's source location to find phantom member whose source ranges are outside the parent's body. This PR is based on PR #3361 by @barry3406 and extends it to check the end offset. It isn't valid C syntax for child cursor to start inside but somehow extend past the parent's body but stricter check is just added for safety.

## Alternatives
Filtering by cursor kind is not sufficient because anonymous members are represented as `StructDecl` cursors, not `FieldDecl`. Walking up the AST and semantic analysis would be more complex.

## Limitations
I think it would be extremely rare but this PR doesn't work for macros and templates defining both a struct member and an aligned attribute with a nested anonymous struct:
```c
#define CONVOLUTED_FIELD struct {int aaa;} __attribute__((aligned(__alignof__(struct {int bbb;}))))

typedef struct macro_t {
    CONVOLUTED_FIELD;
} macro_t;
```
```rs
#[repr(C)]
#[derive(Debug, Default, Copy, Clone)]
pub struct macro_t {
    pub __bindgen_anon_1: macro_t__bindgen_ty_1,
}
#[repr(C)]
#[derive(Debug, Default, Copy, Clone)]
pub struct macro_t__bindgen_ty_1 {
    pub aaa: ::std::os::raw::c_int,
    pub __bindgen_anon_1: macro_t__bindgen_ty_1__bindgen_ty_1,  // <-- incorrect member struct
}
#[repr(C)]
#[derive(Debug, Default, Copy, Clone)]
pub struct macro_t__bindgen_ty_1__bindgen_ty_1 {
    pub bbb: ::std::os::raw::c_int,
}
#[allow(clippy::unnecessary_operation, clippy::identity_op)]
const _: () = {
    [
        "Size of macro_t__bindgen_ty_1__bindgen_ty_1",
    ][::std::mem::size_of::<macro_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
    [
        "Alignment of macro_t__bindgen_ty_1__bindgen_ty_1",
    ][::std::mem::align_of::<macro_t__bindgen_ty_1__bindgen_ty_1>() - 4usize];
    [
        "Offset of field: macro_t__bindgen_ty_1__bindgen_ty_1::bbb",
    ][::std::mem::offset_of!(macro_t__bindgen_ty_1__bindgen_ty_1, bbb) - 0usize];
};
#[allow(clippy::unnecessary_operation, clippy::identity_op)]
const _: () = {
    [
        "Size of macro_t__bindgen_ty_1",
    ][::std::mem::size_of::<macro_t__bindgen_ty_1>() - 4usize];
    [
        "Alignment of macro_t__bindgen_ty_1",
    ][::std::mem::align_of::<macro_t__bindgen_ty_1>() - 4usize];
    [
        "Offset of field: macro_t__bindgen_ty_1::aaa",
    ][::std::mem::offset_of!(macro_t__bindgen_ty_1, aaa) - 0usize];
};
#[allow(clippy::unnecessary_operation, clippy::identity_op)]
const _: () = {
    ["Size of macro_t"][::std::mem::size_of::<macro_t>() - 4usize];
    ["Alignment of macro_t"][::std::mem::align_of::<macro_t>() - 4usize];
};
```