### PR TITLE
chore(bindgen): bump `syn` to v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ dependencies = [
  "regex",
  "shlex",
  "similar",
- "syn",
+ "syn 3.0.3",
  "tempfile",
 ]
 
@@ -214,7 +214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -441,12 +441,12 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -582,6 +582,17 @@ name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default-members = [
 
 [workspace.package]
 # If you change this, also update README.md
-rust-version = "1.70.0"
+rust-version = "1.71.0"
 edition = "2021"
 
 # All dependency version management is centralized here

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libloading = "0.8"
 log = "0.4"
 objc = "0.2"
 owo-colors = "4.1.0"
-prettyplease = "0.2.7"
+prettyplease = "0.3"
 proc-macro2 = "1.0.80"
 quickcheck = "1.0"
 quote = { version = "1", default-features = false }
@@ -44,7 +44,7 @@ regex = { version = "1.5.3", default-features = false }
 rustc-hash = "2.1.0"
 shlex = "2"
 similar = "2.2.1"
-syn = "2.0"
+syn = "3.0"
 tempfile = "3.27.0"
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ extern "C" {
 
 ## MSRV
 
-The `bindgen` minimum supported Rust version is **1.70.0**.
+The `bindgen` minimum supported Rust version is **1.71.0**.
 
-The `bindgen-cli` minimum supported Rust version is **1.70.0**.
+The `bindgen-cli` minimum supported Rust version is **1.71.0**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 


### PR DESCRIPTION
Following the [recent release of `syn` v3](https://github.com/dtolnay/syn/releases/tag/3.0.0), this bumps the dependency with the aim of reducing dependency duplication in dependents.

Because [`syn` v3 advertises an MSRV of 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14), this first bumps the MSRV of `bindgen` from 1.70 to 1.71 (which I think is acceptable).

`syn` v3 of course contains breaking changes: I've been through the changelog but didn't find anything relevant (but there are quite a few of them so I could have missed some). I've run `cargo test` but didn't do any other kind of testing.