### PR TITLE
Increase itertools version range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clang-sys = "1"
 clap = "4"
 clap_complete = "4"
 env_logger = "0.10.0"
-itertools = { version = ">=0.10,<0.15", default-features = false }
+itertools = { version = ">=0.10,<0.16", default-features = false }
 libloading = "0.8"
 log = "0.4"
 objc = "0.2"


### PR DESCRIPTION
Tested locally (didn't update Cargo.lock to avoid potential merge conflicts).