### PR TITLE
refactor(bindgen): remove the dependency on `itertools`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ dependencies = [
  "clang-sys",
  "clap",
  "clap_complete",
- "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -230,12 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,15 +336,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ clang-sys = "1"
 clap = "4"
 clap_complete = "4"
 env_logger = "0.10.0"
-itertools = { version = ">=0.10,<0.15", default-features = false }
 libloading = "0.8"
 log = "0.4"
 objc = "0.2"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -32,7 +32,6 @@ cexpr.workspace = true
 clang-sys = { workspace = true, features = ["clang_11_0"] }
 clap = { workspace = true, features = ["derive"], optional = true }
 clap_complete = { workspace = true, optional = true }
-itertools = { workspace = true }
 log = { workspace = true, optional = true }
 prettyplease = { workspace = true, optional = true, features = ["verbatim"] }
 proc-macro2.workspace = true

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1,7 +1,5 @@
 //! Compound types (unions and structs) in our intermediate representation.
 
-use itertools::Itertools;
-
 use super::analysis::Sizedness;
 use super::annotations::Annotations;
 use super::context::{BindgenContext, FunctionId, ItemId, TypeId, VarId};
@@ -496,22 +494,27 @@ where
         // resulting fields. We introduce a scope here so that we can use
         // `raw_fields` again after the `by_ref` iterator adaptor is dropped.
         {
-            let non_bitfields = raw_fields
-                .by_ref()
-                .peeking_take_while(|f| f.bitfield_width().is_none())
-                .map(|f| Field::DataMember(f.0));
-            fields.extend(non_bitfields);
+            let raw_fields = raw_fields.by_ref();
+            while let Some(raw_field) =
+                raw_fields.next_if(|f| f.bitfield_width().is_none())
+            {
+                fields.push(Field::DataMember(raw_field.0));
+            }
         }
+
+        let mut bitfields = vec![];
 
         // Now gather all the consecutive bitfields. Only consecutive bitfields
         // may potentially share a bitfield allocation unit with each other in
         // the Itanium C++ ABI.
-        let mut bitfields = raw_fields
-            .by_ref()
-            .peeking_take_while(|f| f.bitfield_width().is_some())
-            .peekable();
+        let raw_fields = raw_fields.by_ref();
+        while let Some(raw_field) =
+            raw_fields.next_if(|f| f.bitfield_width().is_some())
+        {
+            bitfields.push(raw_field);
+        }
 
-        if bitfields.peek().is_none() {
+        if bitfields.is_empty() {
             break;
         }
 


### PR DESCRIPTION
This proposes to slightly refactor the only use of `itertools` to be able to remove the dependency on it. Removing the dependency helps reduce the future maintenance burden (e.g., see #3407).

Closes #3407