### PR TITLE
fix: use the latest value when a macro is redefined

### DIFF
--- a/bindgen-tests/tests/expectations/tests/macro-redef.rs
+++ b/bindgen-tests/tests/expectations/tests/macro-redef.rs
@@ -1,4 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-pub const FOO: u32 = 4;
+pub const FOO: u32 = 5;
 pub const BAR: u32 = 5;
 pub const BAZ: u32 = 6;

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -1496,6 +1496,15 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         }
     }
 
+    /// Resolve the given `ItemId` into a mutable reference to an `Item`, or
+    /// `None` if no such item exists.
+    pub(crate) fn resolve_item_mut<Id: Into<ItemId>>(
+        &mut self,
+        id: Id,
+    ) -> Option<&mut Item> {
+        self.items.get_mut(id.into().0)?.as_mut()
+    }
+
     /// Get the current module.
     pub(crate) fn current_module(&self) -> ModuleId {
         self.current_module

--- a/bindgen/ir/item_kind.rs
+++ b/bindgen/ir/item_kind.rs
@@ -108,6 +108,15 @@ impl ItemKind {
         }
     }
 
+    /// Get a mutable reference to this `ItemKind`'s underlying `Var`, or
+    /// `None` if it is some other kind.
+    pub(crate) fn as_var_mut(&mut self) -> Option<&mut Var> {
+        match *self {
+            ItemKind::Var(ref mut v) => Some(v),
+            _ => None,
+        }
+    }
+
     /// Is this a variable?
     pub(crate) fn is_var(&self) -> bool {
         self.as_var().is_some()

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -97,6 +97,13 @@ impl Var {
     pub fn link_name(&self) -> Option<&str> {
         self.link_name.as_deref()
     }
+
+    /// Overwrite this variable's type and value, e.g. when a macro that
+    /// backs it has been redefined to a new value.
+    fn set_val(&mut self, ty: TypeId, val: Option<VarType>) {
+        self.ty = ty;
+        self.val = val;
+    }
 }
 
 impl DotAttributes for Var {
@@ -212,12 +219,6 @@ impl ClangSubItemParser for Var {
                 // derived macros.
                 ctx.note_parsed_macro(id.clone(), value.clone());
 
-                if previously_defined {
-                    let name = String::from_utf8(id).unwrap();
-                    duplicated_macro_diagnostic(&name, cursor.location(), ctx);
-                    return Err(ParseError::Continue);
-                }
-
                 // NOTE: Unwrapping, here and above, is safe, because the
                 // identifier of a token comes straight from clang, and we
                 // enforce utf8 there, so we should have already panicked at
@@ -263,6 +264,28 @@ impl ClangSubItemParser for Var {
                 };
 
                 let ty = Item::builtin_type(type_kind, true, ctx);
+
+                if previously_defined {
+                    let existing_id = ctx.items().find_map(|(id, item)| {
+                        let var = item.kind().as_var()?;
+                        (var.name() == name).then_some(id)
+                    });
+
+                    if let Some(existing_id) = existing_id {
+                        duplicated_macro_diagnostic(
+                            &name,
+                            cursor.location(),
+                            ctx,
+                        );
+                        if let Some(existing_var) = ctx
+                            .resolve_item_mut(existing_id)
+                            .and_then(|item| item.kind_mut().as_var_mut())
+                        {
+                            existing_var.set_val(ty, Some(val));
+                        }
+                        return Ok(ParseResult::AlreadyResolved(existing_id));
+                    }
+                }
 
                 Ok(ParseResult::New(
                     Var::new(name, None, None, ty, Some(val), true),
@@ -481,7 +504,7 @@ fn duplicated_macro_diagnostic(
     _location: clang::SourceLocation,
     _ctx: &BindgenContext,
 ) {
-    warn!("Duplicated macro definition: {macro_name}");
+    warn!("Macro '{macro_name}' redefined; using the latest definition");
 
     #[cfg(feature = "experimental")]
     // FIXME (pvdrz & amanjeev): This diagnostic message shows way too often to be actually


### PR DESCRIPTION
## Summary

Fixes #2722.

When a C header redefines a macro (`#define A 1` ... later ... `#define A 2`), bindgen emitted `pub const A: ... = 1;` — the value from the *first* definition — instead of the last one.

`ctx.parsed_macros` already tracked the latest value internally (used when evaluating other macro expressions that reference the redefined macro), but `Var::parse` bailed out on redefinition before ever updating the already-emitted `Var` item, so the first-defined value stuck around in the generated bindings.

## Change

On redefinition, `Var::parse` now finds the already-emitted `Var` item by name and updates its type/value in place (via new `BindgenContext::resolve_item_mut` and `ItemKind::as_var_mut` accessors), returning `ParseResult::AlreadyResolved` instead of silently discarding the redefinition.

The existing `macro-redef.h` / `macro-redef.rs` test pair already encoded this exact bug (`FOO` was expected to be `4`, the first definition, while `BAR`/`BAZ`, which are expressions referencing `FOO`, were already correctly computed using the latest value). Updated the expectation so `FOO` is now `5`, matching the last definition.

## Scope note

`#undef` handling (raised in the issue thread) is intentionally left out of scope: libclang's `CXCursor` enum has no `MacroUndef`/undefinition kind, so `#undef` directives aren't observable via the cursor-based traversal bindgen currently uses. There's already a maintainer `FIXME` in `var.rs` acknowledging this same limitation. This PR implements "latest definition wins," which is what was explicitly endorsed in the issue thread.

## Test plan

- [x] `macro-redef.rs` expectation updated and passing
- [x] Full `bindgen-tests` corpus (624 headers) passes, aside from 2 pre-existing unrelated failures confirmed present on unmodified `main` (a const-generics codegen difference tied to this environment's Rust/clang toolchain versions, and a `dump_preprocessed_input` test that needs the `clang` CLI binary rather than just `libclang`)
- [x] `cargo clippy -- -D warnings` clean
- [x] Manually confirmed the only other macro name collisions in the test corpus (`RTE_STD_C11`, several `JSVAL_TAG_*`) are mutually-exclusive `#if`/`#elif` branches, not real redefinitions, so this change doesn't affect them