### PR TITLE
Remove needless by_ref calls

### DIFF
--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -491,15 +491,11 @@ where
 
     loop {
         // While we have plain old data members, just keep adding them to our
-        // resulting fields. We introduce a scope here so that we can use
-        // `raw_fields` again after the `by_ref` iterator adaptor is dropped.
+        // resulting fields.
+        while let Some(raw_field) =
+            raw_fields.next_if(|f| f.bitfield_width().is_none())
         {
-            let raw_fields = raw_fields.by_ref();
-            while let Some(raw_field) =
-                raw_fields.next_if(|f| f.bitfield_width().is_none())
-            {
-                fields.push(Field::DataMember(raw_field.0));
-            }
+            fields.push(Field::DataMember(raw_field.0));
         }
 
         let mut bitfields = vec![];
@@ -507,7 +503,6 @@ where
         // Now gather all the consecutive bitfields. Only consecutive bitfields
         // may potentially share a bitfield allocation unit with each other in
         // the Itanium C++ ABI.
-        let raw_fields = raw_fields.by_ref();
         while let Some(raw_field) =
             raw_fields.next_if(|f| f.bitfield_width().is_some())
         {

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -858,7 +858,7 @@ impl Item {
         }
 
         // Ancestors' ID iter
-        let mut ids_iter = target
+        let ids_iter = target
             .parent_id()
             .ancestors(ctx)
             .filter(|id| *id != ctx.root_module())
@@ -884,7 +884,7 @@ impl Item {
 
             // If target is anonymous we need find its first named ancestor.
             if target.is_anon() {
-                for id in ids_iter.by_ref() {
+                for id in ids_iter {
                     ids.push(id);
 
                     if !ctx.resolve_item(id).is_anon() {


### PR DESCRIPTION
Follow-up to #3408. The `by_ref` calls in that file were already redundant before itertools was removed, because `peeking_take_while` doesn't consume the iterator either.

Also found one other place not related to the above PR where `by_ref` was called for no good reason.