### PR TITLE
fix: generate a Debug impl for NewType/NewTypeDeref wrappers when the inner type only manually implements it

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-3268-newtype-deref-union-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3268-newtype-deref-union-debug.rs
@@ -1,0 +1,80 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union Union {
+    pub bytes: [::std::os::raw::c_uchar; 4usize],
+    pub word: ::std::os::raw::c_uint,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Union"][::std::mem::size_of::<Union>() - 4usize];
+    ["Alignment of Union"][::std::mem::align_of::<Union>() - 4usize];
+    ["Offset of field: Union::bytes"][::std::mem::offset_of!(Union, bytes) - 0usize];
+    ["Offset of field: Union::word"][::std::mem::offset_of!(Union, word) - 0usize];
+};
+impl Default for Union {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for Union {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "Union {{ union }}")
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub struct UnionAlias(pub Union);
+impl ::std::ops::Deref for UnionAlias {
+    type Target = Union;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl ::std::ops::DerefMut for UnionAlias {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl ::std::fmt::Debug for UnionAlias {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        f.debug_tuple(stringify!(UnionAlias)).field(&self.0).finish()
+    }
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct StructContainingUnionAlias {
+    pub ua: UnionAlias,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    [
+        "Size of StructContainingUnionAlias",
+    ][::std::mem::size_of::<StructContainingUnionAlias>() - 4usize];
+    [
+        "Alignment of StructContainingUnionAlias",
+    ][::std::mem::align_of::<StructContainingUnionAlias>() - 4usize];
+    [
+        "Offset of field: StructContainingUnionAlias::ua",
+    ][::std::mem::offset_of!(StructContainingUnionAlias, ua) - 0usize];
+};
+impl Default for StructContainingUnionAlias {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl ::std::fmt::Debug for StructContainingUnionAlias {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        write!(f, "StructContainingUnionAlias {{ ua: {:?} }}", self.ua)
+    }
+}

--- a/bindgen-tests/tests/headers/issue-3268-newtype-deref-union-debug.h
+++ b/bindgen-tests/tests/headers/issue-3268-newtype-deref-union-debug.h
@@ -1,0 +1,12 @@
+// bindgen-flags: --impl-debug --default-alias-style=new_type_deref
+
+union Union {
+  unsigned char bytes[4];
+  unsigned int word;
+};
+
+typedef union Union UnionAlias;
+
+struct StructContainingUnionAlias {
+  UnionAlias ua;
+};

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1076,6 +1076,7 @@ impl CodeGenerator for Type {
                 };
 
                 let alias_style = item.alias_style(ctx);
+                let mut needs_debug_impl = false;
 
                 // We prefer using `pub use` over `pub type` because of:
                 // https://github.com/rust-lang/rust/issues/26264
@@ -1107,6 +1108,12 @@ impl CodeGenerator for Type {
                         let packed = false; // Types can't be packed in Rust.
                         let derivable_traits =
                             derives_of_item(item, ctx, packed);
+                        if !derivable_traits.contains(DerivableTraits::DEBUG) {
+                            needs_debug_impl = ctx.options().derive_debug &&
+                                ctx.options().impl_debug &&
+                                !ctx.no_debug_by_name(item) &&
+                                !item.annotations().disallow_debug();
+                        }
                         let mut derives: Vec<_> = derivable_traits.into();
                         // The custom derives callback may return a list of derive attributes;
                         // add them to the end of the list.
@@ -1233,6 +1240,17 @@ impl CodeGenerator for Type {
                             #[inline]
                             fn deref_mut(&mut self) -> &mut Self::Target {
                                 &mut self.0
+                            }
+                        }
+                    });
+                }
+
+                if needs_debug_impl {
+                    let prefix = ctx.trait_prefix();
+                    tokens.append_all(quote! {
+                        impl ::#prefix::fmt::Debug for #rust_name {
+                            fn fmt(&self, f: &mut ::#prefix::fmt::Formatter<'_>) -> ::#prefix::fmt::Result {
+                                f.debug_tuple(stringify!(#rust_name)).field(&self.0).finish()
                             }
                         }
                     });


### PR DESCRIPTION
## Summary

Fixes #3268.

When using `--impl-debug` together with `--default-alias-style=new_type` or `new_type_deref`, a newtype wrapper around a type that only has a *manual* `Debug` impl (e.g. a union, which can never `#[derive(Debug)]` and always gets a hand-written impl instead) ends up with **no** `Debug` impl at all — neither derived nor manual. Any containing struct that references the wrapper still generates a manual `Debug` impl formatting the field with `{:?}`, so the generated code fails to compile:

```
error[E0277]: `UnionAlias` doesn't implement `Debug`
```

This is the exact repro and error from the issue.

## Root cause

`Type::codegen`'s `AliasVariation::NewType | AliasVariation::NewTypeDeref` branch only ever builds a `#[derive(...)]` list via `derives_of_item`. Unlike `CompInfo::codegen` (the regular struct/union codegen path), it never falls back to generating a manual `impl Debug` when `Debug` isn't in the derivable set.

## Fix

Mirror the same "not derivable → generate a manual impl instead, if `--impl-debug` and friends allow it" logic that `CompInfo::codegen` already has (`codegen/mod.rs:2588-2593` / `2931-2932`), for the newtype wrapper case. The generated impl delegates via `f.debug_tuple(...).field(&self.0).finish()`, matching what `#[derive(Debug)]` would produce for a tuple struct (including correct `{:#?}` pretty-printing).

## Test plan

- [x] Reproduced the exact compile failure from the issue against unmodified `main` (`rustc` confirms `E0277`, same as the report)
- [x] New regression test `issue-3268-newtype-deref-union-debug.h`/`.rs`, using the issue's exact repro
- [x] Confirmed the fixed output actually compiles (`rustc --crate-type lib` on the generated bindings)
- [x] Full `bindgen-tests` corpus passes aside from 2 pre-existing, unrelated failures also present on unmodified `main` (a toolchain-version-dependent const-generics codegen difference, and a `dump_preprocessed_input` test needing the `clang` CLI binary rather than just `libclang`)
- [x] `cargo clippy -- -D warnings` clean

## Scope note

The issue's second comment describes a related-looking but distinct bug (a struct field is silently omitted from the generated `Debug` format string when its type is a `stdint.h` typedef like `uint32_t`). I wasn't able to reproduce that one with several plausible flag/header combinations in my environment, so I'm leaving it out of this PR rather than guessing at a fix for behavior I can't actually observe. Happy to take a look if someone can share a minimal, reliably-reproducing case.