### PR TITLE
chore: fix rustfmt TOML

### DIFF
--- a/bindgen-tests/tests/rustfmt.toml
+++ b/bindgen-tests/tests/rustfmt.toml
@@ -1,3 +1,3 @@
 normalize_doc_attributes = true
 max_width = 80
-binop_separator = "back"
+binop_separator = "Back"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
 max_width = 80
-binop_separator = "back"
+binop_separator = "Back"


### PR DESCRIPTION
```log
  Error: The value must be one of ["Front", "Back"], but found "back"
    at ./rustfmt.toml:2:19
```