### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -1,9 +1,6 @@
 lints.workspace = true
 
 [package]
-authors = [
-    "The rust-bindgen project contributors",
-]
 description = "Automatically generates Rust FFI bindings to C and C++ libraries."
 keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]

--- a/bindgen-integration/Cargo.toml
+++ b/bindgen-integration/Cargo.toml
@@ -4,7 +4,6 @@ lints.workspace = true
 name = "bindgen-integration"
 description = "A package to test various bindgen features"
 version = "0.1.0"
-authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 publish = false
 build = "build.rs"
 rust-version.workspace = true

--- a/bindgen-tests/tests/expectations/Cargo.toml
+++ b/bindgen-tests/tests/expectations/Cargo.toml
@@ -2,11 +2,6 @@
 name = "tests_expectations"
 description = "bindgen results when ran on ../headers/*"
 version = "0.0.0"
-authors = [
-  "Jyun-Yan You <jyyou.tw@gmail.com>",
-  "Emilio Cobos Álvarez <emilio@crisal.io>",
-  "The Servo project developers",
-]
 publish = false
 rust-version.workspace = true
 edition.workspace = true

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,12 +1,6 @@
 lints.workspace = true
 
 [package]
-authors = [
-    "Jyun-Yan You <jyyou.tw@gmail.com>",
-    "Emilio Cobos Álvarez <emilio@crisal.io>",
-    "Nick Fitzgerald <fitzgen@gmail.com>",
-    "The Servo project developers",
-]
 description = "Automatically generates Rust FFI bindings to C and C++ libraries."
 keywords = ["bindings", "ffi", "code-generation"]
 categories = ["external-ffi-bindings", "development-tools::ffi"]


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068