### PR TITLE
Don't derive or implement traits for newtype aliases to `c_void`

### DIFF
--- a/bindgen-tests/tests/expectations/tests/typedef-void-newtype.rs
+++ b/bindgen-tests/tests/expectations/tests/typedef-void-newtype.rs
@@ -1,0 +1,3 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(transparent)]
+pub struct myvoid(pub ::std::os::raw::c_void);

--- a/bindgen-tests/tests/headers/typedef-void-newtype.h
+++ b/bindgen-tests/tests/headers/typedef-void-newtype.h
@@ -1,0 +1,2 @@
+// bindgen-flags: --new-type-alias myvoid --with-derive-hash --with-derive-partialeq --with-derive-partialord --with-derive-eq --with-derive-ord --impl-debug --impl-partialeq
+typedef void myvoid;

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1036,6 +1036,9 @@ impl CodeGenerator for Type {
                         .with_implicit_template_params(ctx, inner_item)
                 };
 
+                let inner_canon_type =
+                    inner_item.expect_type().canonical_type(ctx);
+
                 {
                     // FIXME(emilio): This is a workaround to avoid generating
                     // incorrect type aliases because of types that we haven't
@@ -1047,8 +1050,6 @@ impl CodeGenerator for Type {
                     // with invalid template parameters, and at least this way
                     // they can be replaced, instead of generating plain invalid
                     // code.
-                    let inner_canon_type =
-                        inner_item.expect_type().canonical_type(ctx);
                     if inner_canon_type.is_invalid_type_param() {
                         warn!(
                             "Item contained invalid named type, skipping: \
@@ -1112,7 +1113,8 @@ impl CodeGenerator for Type {
                             needs_debug_impl = ctx.options().derive_debug &&
                                 ctx.options().impl_debug &&
                                 !ctx.no_debug_by_name(item) &&
-                                !item.annotations().disallow_debug();
+                                !item.annotations().disallow_debug() &&
+                                !inner_canon_type.is_void();
                         }
                         let mut derives: Vec<_> = derivable_traits.into();
                         // The custom derives callback may return a list of derive attributes;
@@ -1126,7 +1128,9 @@ impl CodeGenerator for Type {
                             });
                         // In most cases this will be a no-op, since custom_derives will be empty.
                         append_custom_derives(&mut derives, &custom_derives);
-                        attributes.push(attributes::derives(&derives));
+                        if !derives.is_empty() {
+                            attributes.push(attributes::derives(&derives));
+                        }
 
                         let custom_attributes =
                             ctx.options().all_callbacks(|cb| {

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -189,7 +189,6 @@ impl CannotDerive<'_> {
         match *ty.kind() {
             // Handle the simple cases. These can derive traits without further
             // information.
-            TypeKind::Void |
             TypeKind::NullPtr |
             TypeKind::Int(..) |
             TypeKind::Complex(..) |
@@ -213,6 +212,7 @@ impl CannotDerive<'_> {
             TypeKind::Function(ref sig) => {
                 self.derive_trait.can_derive_fnptr(sig)
             }
+            TypeKind::Void => CanDerive::No,
 
             // Complex cases need more information
             TypeKind::Array(t, len) => {
@@ -534,7 +534,6 @@ impl DeriveTrait {
             // === Default ===
             (
                 DeriveTrait::Default,
-                TypeKind::Void |
                 TypeKind::NullPtr |
                 TypeKind::Enum(..) |
                 TypeKind::Reference(..) |


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/2964. See also https://github.com/rust-lang/rust/pull/160115