### PR TITLE
feat: add --opaque-type-alias-as-c-void option

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-1874-opaque-type-alias-as-c-void.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1874-opaque-type-alias-as-c-void.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug)]
+pub struct _WINDOW {
+    _unused: [u8; 0],
+}
+pub type WINDOW = ::std::os::raw::c_void;
+unsafe extern "C" {
+    pub fn wgetch(win: *mut WINDOW) -> ::std::os::raw::c_int;
+}

--- a/bindgen-tests/tests/headers/issue-1874-opaque-type-alias-as-c-void.h
+++ b/bindgen-tests/tests/headers/issue-1874-opaque-type-alias-as-c-void.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --opaque-type WINDOW --opaque-type-alias-as-c-void
+
+typedef struct _WINDOW WINDOW;
+
+int wgetch(WINDOW *win);

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1025,7 +1025,11 @@ impl CodeGenerator for Type {
                 let is_opaque = item.is_opaque(ctx, &());
                 let inner_rust_type = if is_opaque {
                     outer_params = vec![];
-                    self.to_opaque(ctx, item)
+                    if ctx.options().opaque_type_alias_as_c_void {
+                        helpers::ast_ty::c_void(ctx)
+                    } else {
+                        self.to_opaque(ctx, item)
+                    }
                 } else {
                     // Its possible that we have better layout information than
                     // the inner type does, so fall back to an opaque blob based

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -358,6 +358,9 @@ struct BindgenCommand {
     /// Mark TYPE as opaque.
     #[arg(long, value_name = "TYPE")]
     opaque_type: Vec<String>,
+    /// Emit opaque type aliases as `c_void` instead of a sized byte blob.
+    #[arg(long)]
+    opaque_type_alias_as_c_void: bool,
     ///  Write Rust bindings to OUTPUT.
     #[arg(long, short, value_name = "OUTPUT")]
     output: Option<String>,
@@ -649,6 +652,7 @@ where
         no_include_path_detection,
         fit_macro_constant_types,
         opaque_type,
+        opaque_type_alias_as_c_void,
         output,
         raw_line,
         module_raw_line,
@@ -964,6 +968,7 @@ where
             generate_cstr,
             block_extern_crate,
             opaque_type,
+            opaque_type_alias_as_c_void,
             raw_line,
             use_core => |b, _| b.use_core(),
             distrust_clang_mangling => |b, _| b.trust_clang_mangling(false),

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -313,6 +313,24 @@ options! {
         },
         as_args: "--opaque-type",
     },
+    /// Whether to emit opaque type aliases as `c_void` instead of a sized byte blob.
+    opaque_type_alias_as_c_void: bool {
+        methods: {
+            /// Set whether opaque type aliases should be emitted as `c_void` instead of a
+            /// sized byte blob (e.g. `[u64; 11usize]`).
+            ///
+            /// This is useful for types that are only ever handled behind a pointer (e.g.
+            /// `WINDOW` in curses), where communicating "this can't be read from or written to
+            /// directly" is more valuable than preserving the type's size and alignment.
+            ///
+            /// This option is disabled by default.
+            pub fn opaque_type_alias_as_c_void(mut self, doit: bool) -> Self {
+                self.options.opaque_type_alias_as_c_void = doit;
+                self
+            }
+        },
+        as_args: "--opaque-type-alias-as-c-void",
+    },
     /// The explicit `rustfmt` path.
     rustfmt_path: Option<PathBuf> {
         methods: {


### PR DESCRIPTION
## Summary

Fixes #1874.

Adds an option to emit opaque type aliases as `c_void` instead of a sized byte blob, e.g.:

```rust
// before
pub type WINDOW = [u64; 11usize];

// after, with --opaque-type-alias-as-c-void
pub type WINDOW = ::core::ffi::c_void;
```

This is useful for types that are only ever handled behind a pointer (e.g. `WINDOW` in curses), where communicating "this can't be read from or written to directly" is more valuable than preserving the type's size and alignment through a same-sized blob.

## Implementation

- New `bool` option `opaque_type_alias_as_c_void`, following the exact same shape as the existing `impl_debug` option (`bindgen/options/mod.rs`), including CLI wiring in `bindgen/options/cli.rs` (`--opaque-type-alias-as-c-void`).
- Wired into the opaque type-alias codegen branch in `bindgen/codegen/mod.rs` (`Type::codegen`'s `TypeKind::Alias`/`TemplateAlias` handling): when the option is set and the alias target is opaque, emits `helpers::ast_ty::c_void(ctx)` instead of the usual `self.to_opaque(ctx, item)` blob.
- Reuses the pre-existing `helpers::ast_ty::c_void` helper (already used elsewhere for `TypeKind::Void`/`TypeKind::NullPtr`), so `--ctypes-prefix` and `--use-core` are automatically respected with no extra code.

## Scope

This only affects the top-level opaque type-alias path (`typedef struct Foo Foo;`-style declarations), matching the issue's own example exactly. It does *not* affect:
- Opaque `struct`/`union` declared without a typedef (a separate codegen path in `CompInfo::codegen`).
- Opaque struct *fields* (which go through the unconditional `ToOpaque` blanket impl used for padding/layout elsewhere, and must stay sized for the containing type's layout to be correct).

## Test plan

- [x] New regression test `issue-1874-opaque-type-alias-as-c-void.h`/`.rs`, using a `WINDOW`-style opaque typedef (the issue's own motivating example).
- [x] Manually confirmed via the built CLI: flag off → unchanged `pub type WINDOW = u8;` blob output (no regression); flag on → `pub type WINDOW = ::std::os::raw::c_void;`; flag on + `--use-core` → `pub type WINDOW = ::core::ffi::c_void;`.
- [x] Confirmed the generated output actually compiles (`rustc --crate-type lib`).
- [x] Full `bindgen-tests` corpus passes aside from 2 pre-existing, unrelated failures also present on unmodified `main` (a toolchain-version-dependent const-generics codegen difference, and a `dump_preprocessed_input` test needing the `clang` CLI binary rather than just `libclang`).
- [x] `cargo clippy -p bindgen -p bindgen-cli --all-targets -- -D warnings` clean.