### PR TITLE
Pass system header paths to fallback parser

### DIFF
--- a/bindgen-tests/tests/expectations/tests/macro-fallback-include-builtin.rs
+++ b/bindgen-tests/tests/expectations/tests/macro-fallback-include-builtin.rs
@@ -1,0 +1,2 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const TEST: u32 = 42;

--- a/bindgen-tests/tests/headers/macro-fallback-include-builtin.h
+++ b/bindgen-tests/tests/headers/macro-fallback-include-builtin.h
@@ -1,0 +1,7 @@
+// bindgen-flags: --clang-macro-fallback --allowlist-item TEST
+// Ensures that the fallback path for macros doesn't silently
+// fail because of builtin headers not being found.
+
+#include <stddef.h>
+
+#define TEST ((size_t)42)

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -871,7 +871,10 @@ impl Bindings {
                 for path in search_paths {
                     if let Ok(path) = path.into_os_string().into_string() {
                         options.clang_args.push("-isystem".into());
-                        options.clang_args.push(path.into_boxed_str());
+                        options.clang_args.push(path.clone().into_boxed_str());
+
+                        options.fallback_clang_args.push("-isystem".into());
+                        options.fallback_clang_args.push(path.into_boxed_str());
                     }
                 }
             }


### PR DESCRIPTION
This is similar to https://github.com/rust-lang/rust-bindgen/pull/3353 but for automatically detected header paths.

Consider
```c
#include <stddef.h>

#define TEST ((size_t)42)
```

To create a binding for `TEST`, bindgen uses the fallback path to parse macros. Currently though it silently fails because of the inclusion of `stddef.h`, which is a header provided by the compiler (at least in the case of GCC and clang on `x86_64-pc-linux-gnu`), since the fallback parser is unaware of the location of that header. This PR makes it so that detected system header paths are passed to the fallback parser as well.