### PR TITLE
ty: Use underlying layout of typedefs if available.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-3406.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3406.rs
@@ -11,6 +11,8 @@ const _: () = {
     ["Alignment of Inner"][::std::mem::align_of::<Inner>() - 16usize];
     ["Offset of field: Inner::byte"][::std::mem::offset_of!(Inner, byte) - 0usize];
 };
+pub type AlignedInt = ::std::os::raw::c_int;
+pub type NestedAlignedInt = AlignedInt;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -24,4 +26,52 @@ const _: () = {
     ["Alignment of Outer"][::std::mem::align_of::<Outer>() - 16usize];
     ["Offset of field: Outer::before"][::std::mem::offset_of!(Outer, before) - 0usize];
     ["Offset of field: Outer::inner"][::std::mem::offset_of!(Outer, inner) - 16usize];
+};
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Outer2 {
+    pub before: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: [u8; 12usize],
+    pub one: AlignedInt,
+    pub __bindgen_padding_1: [u8; 12usize],
+    pub two: AlignedInt,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Outer2"][::std::mem::size_of::<Outer2>() - 48usize];
+    ["Alignment of Outer2"][::std::mem::align_of::<Outer2>() - 16usize];
+    ["Offset of field: Outer2::before"][::std::mem::offset_of!(Outer2, before) - 0usize];
+    ["Offset of field: Outer2::one"][::std::mem::offset_of!(Outer2, one) - 16usize];
+    ["Offset of field: Outer2::two"][::std::mem::offset_of!(Outer2, two) - 32usize];
+};
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Outer3 {
+    pub before: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: [u8; 12usize],
+    pub inner: AlignedInt,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Outer3"][::std::mem::size_of::<Outer3>() - 32usize];
+    ["Alignment of Outer3"][::std::mem::align_of::<Outer3>() - 16usize];
+    ["Offset of field: Outer3::before"][::std::mem::offset_of!(Outer3, before) - 0usize];
+    ["Offset of field: Outer3::inner"][::std::mem::offset_of!(Outer3, inner) - 16usize];
+};
+#[repr(C)]
+#[repr(align(16))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Outer4 {
+    pub before: ::std::os::raw::c_int,
+    pub __bindgen_padding_0: [u8; 12usize],
+    pub inner: NestedAlignedInt,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Outer4"][::std::mem::size_of::<Outer4>() - 32usize];
+    ["Alignment of Outer4"][::std::mem::align_of::<Outer4>() - 16usize];
+    ["Offset of field: Outer4::before"][::std::mem::offset_of!(Outer4, before) - 0usize];
+    ["Offset of field: Outer4::inner"][::std::mem::offset_of!(Outer4, inner) - 16usize];
 };

--- a/bindgen-tests/tests/headers/issue-3406.h
+++ b/bindgen-tests/tests/headers/issue-3406.h
@@ -2,7 +2,26 @@ struct __attribute__((aligned(16))) Inner {
     char byte;
 };
 
+typedef int AlignedInt __attribute__((aligned(16)));
+typedef AlignedInt NestedAlignedInt;
+
 struct Outer {
     int before;
     struct Inner inner;
+};
+
+struct Outer2 {
+    int before;
+    AlignedInt one;
+    AlignedInt two;
+};
+
+struct Outer3 {
+    int before;
+    AlignedInt inner;
+};
+
+struct Outer4 {
+    int before;
+    NestedAlignedInt inner;
 };

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -218,6 +218,15 @@ impl Type {
 
     /// What is the layout of this type?
     pub(crate) fn layout(&self, ctx: &BindgenContext) -> Option<Layout> {
+        if let TypeKind::Alias(inner) | TypeKind::ResolvedTypeRef(inner) =
+            self.kind
+        {
+            // HACK(emilio): Rust can't represent over-aligned typedefs, so prefer the inner type's
+            // layout if available, to get struct layout correct at least...
+            if let Some(l) = ctx.resolve_type(inner).layout(ctx) {
+                return Some(l);
+            }
+        }
         self.layout.or_else(|| {
             match self.kind {
                 TypeKind::Comp(ref ci) => ci.layout(ctx),


### PR DESCRIPTION
This fixes struct layout issues with over-aligned typedefs, which rust can't represent, see #3449 for context and some other discussion.

This is kinda ugly tho, but as far as I can tell there's no good way of getting the right ABI and struct layout at the same time...