### PR TITLE
codegen: Revert some bitfield codegen changes and silence unnecessary_transmutes instead.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/align_bitfields_32bit.rs
+++ b/bindgen-tests/tests/expectations/tests/align_bitfields_32bit.rs
@@ -515,27 +515,39 @@ pub struct StructWithBitfieldAndDouble {
 }
 impl StructWithBitfieldAndDouble {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bitfield(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bitfield(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bitfield_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bitfield(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bitfield_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bitfield_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -545,6 +557,7 @@ impl StructWithBitfieldAndDouble {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         bitfield: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
@@ -554,7 +567,7 @@ impl StructWithBitfieldAndDouble {
                 0usize,
                 32u8,
             >({
-                let bitfield: u32 = bitfield as _;
+                let bitfield: u32 = unsafe { ::std::mem::transmute(bitfield) };
                 bitfield as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -518,27 +518,39 @@ const _: () = {
 };
 impl MuchBitfield {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m0(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m0(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m0_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m0(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m0_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m0_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -548,27 +560,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m1(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m1(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m1_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m1(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m1_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m1_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -578,27 +602,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m2(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m2(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m2_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m2(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m2_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m2_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -608,27 +644,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m3(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<3usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m3(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m3_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m3(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m3_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    3usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m3_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -638,27 +686,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m4(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<4usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m4(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m4_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m4(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m4_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    4usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m4_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -668,27 +728,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m5(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<5usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m5(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m5_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m5(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m5_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    5usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m5_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -698,27 +770,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m6(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<6usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m6(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m6_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m6(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m6_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    6usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m6_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -728,27 +812,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m7(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<7usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m7(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m7_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m7(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m7_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    7usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m7_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -758,27 +854,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m8(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<8usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m8(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m8_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m8(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m8_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    8usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m8_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -788,27 +896,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m9(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<9usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m9(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m9_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m9(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m9_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    9usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m9_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -818,27 +938,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m10(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<10usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m10(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m10_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<10usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m10(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m10_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    10usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m10_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -848,27 +980,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m11(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<11usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m11(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m11_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<11usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m11(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m11_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    11usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m11_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -878,27 +1022,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m12(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<12usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m12(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m12_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<12usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m12(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m12_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    12usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m12_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -908,27 +1064,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m13(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<13usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m13(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m13_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<13usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<13usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m13(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m13_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    13usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m13_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -938,27 +1106,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m14(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<14usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m14(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m14_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<14usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m14(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m14_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    14usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m14_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -968,27 +1148,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m15(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<15usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m15(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m15_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<15usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<15usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m15(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m15_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    15usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m15_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -998,27 +1190,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m16(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<16usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m16(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m16_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<16usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m16(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m16_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    16usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m16_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1028,27 +1232,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m17(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<17usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m17(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m17_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<17usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<17usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m17(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m17_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    17usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m17_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1058,27 +1274,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m18(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<18usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m18(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m18_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<18usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<18usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m18(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m18_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    18usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m18_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1088,27 +1316,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m19(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<19usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m19(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m19_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<19usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<19usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m19(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m19_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    19usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m19_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1118,27 +1358,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m20(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<20usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m20(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m20_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<20usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m20(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m20_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    20usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m20_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1148,27 +1400,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m21(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<21usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m21(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m21_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<21usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<21usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m21(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m21_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    21usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m21_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1178,27 +1442,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m22(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<22usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m22(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m22_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<22usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<22usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m22(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m22_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    22usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m22_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1208,27 +1484,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m23(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<23usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m23(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m23_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<23usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m23(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m23_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    23usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m23_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1238,27 +1526,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m24(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<24usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m24(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m24_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<24usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m24(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m24_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    24usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m24_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1268,27 +1568,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m25(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<25usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m25(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m25_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<25usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<25usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m25(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m25_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    25usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m25_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1298,27 +1610,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m26(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<26usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m26(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m26_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<26usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<26usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m26(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m26_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    26usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m26_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1328,27 +1652,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m27(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<27usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m27(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m27_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<27usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<27usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m27(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m27_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    27usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m27_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1358,27 +1694,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m28(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<28usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m28(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m28_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<28usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<28usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m28(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m28_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    28usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m28_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1388,27 +1736,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m29(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<29usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m29(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m29_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<29usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<29usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m29(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m29_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    29usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m29_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1418,27 +1778,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m30(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<30usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m30(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m30_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<30usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<30usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m30(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m30_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    30usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m30_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1448,27 +1820,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m31(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<31usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m31(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m31_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m31(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m31_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    31usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m31_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1478,27 +1862,39 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn m32(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<32usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_m32(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn m32_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 5usize],
-            >>::raw_get_const::<32usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_m32(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn m32_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 5usize],
+                >>::raw_get_const::<
+                    32usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_m32_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 5usize],
             >>::raw_set_const::<
@@ -1508,6 +1904,7 @@ impl MuchBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         m0: ::std::os::raw::c_char,
         m1: ::std::os::raw::c_char,
@@ -1549,7 +1946,7 @@ impl MuchBitfield {
                 0usize,
                 1u8,
             >({
-                let m0: u8 = m0 as _;
+                let m0: u8 = unsafe { ::std::mem::transmute(m0) };
                 m0 as u64
             });
         __bindgen_bitfield_unit
@@ -1557,7 +1954,7 @@ impl MuchBitfield {
                 1usize,
                 1u8,
             >({
-                let m1: u8 = m1 as _;
+                let m1: u8 = unsafe { ::std::mem::transmute(m1) };
                 m1 as u64
             });
         __bindgen_bitfield_unit
@@ -1565,7 +1962,7 @@ impl MuchBitfield {
                 2usize,
                 1u8,
             >({
-                let m2: u8 = m2 as _;
+                let m2: u8 = unsafe { ::std::mem::transmute(m2) };
                 m2 as u64
             });
         __bindgen_bitfield_unit
@@ -1573,7 +1970,7 @@ impl MuchBitfield {
                 3usize,
                 1u8,
             >({
-                let m3: u8 = m3 as _;
+                let m3: u8 = unsafe { ::std::mem::transmute(m3) };
                 m3 as u64
             });
         __bindgen_bitfield_unit
@@ -1581,7 +1978,7 @@ impl MuchBitfield {
                 4usize,
                 1u8,
             >({
-                let m4: u8 = m4 as _;
+                let m4: u8 = unsafe { ::std::mem::transmute(m4) };
                 m4 as u64
             });
         __bindgen_bitfield_unit
@@ -1589,7 +1986,7 @@ impl MuchBitfield {
                 5usize,
                 1u8,
             >({
-                let m5: u8 = m5 as _;
+                let m5: u8 = unsafe { ::std::mem::transmute(m5) };
                 m5 as u64
             });
         __bindgen_bitfield_unit
@@ -1597,7 +1994,7 @@ impl MuchBitfield {
                 6usize,
                 1u8,
             >({
-                let m6: u8 = m6 as _;
+                let m6: u8 = unsafe { ::std::mem::transmute(m6) };
                 m6 as u64
             });
         __bindgen_bitfield_unit
@@ -1605,7 +2002,7 @@ impl MuchBitfield {
                 7usize,
                 1u8,
             >({
-                let m7: u8 = m7 as _;
+                let m7: u8 = unsafe { ::std::mem::transmute(m7) };
                 m7 as u64
             });
         __bindgen_bitfield_unit
@@ -1613,7 +2010,7 @@ impl MuchBitfield {
                 8usize,
                 1u8,
             >({
-                let m8: u8 = m8 as _;
+                let m8: u8 = unsafe { ::std::mem::transmute(m8) };
                 m8 as u64
             });
         __bindgen_bitfield_unit
@@ -1621,7 +2018,7 @@ impl MuchBitfield {
                 9usize,
                 1u8,
             >({
-                let m9: u8 = m9 as _;
+                let m9: u8 = unsafe { ::std::mem::transmute(m9) };
                 m9 as u64
             });
         __bindgen_bitfield_unit
@@ -1629,7 +2026,7 @@ impl MuchBitfield {
                 10usize,
                 1u8,
             >({
-                let m10: u8 = m10 as _;
+                let m10: u8 = unsafe { ::std::mem::transmute(m10) };
                 m10 as u64
             });
         __bindgen_bitfield_unit
@@ -1637,7 +2034,7 @@ impl MuchBitfield {
                 11usize,
                 1u8,
             >({
-                let m11: u8 = m11 as _;
+                let m11: u8 = unsafe { ::std::mem::transmute(m11) };
                 m11 as u64
             });
         __bindgen_bitfield_unit
@@ -1645,7 +2042,7 @@ impl MuchBitfield {
                 12usize,
                 1u8,
             >({
-                let m12: u8 = m12 as _;
+                let m12: u8 = unsafe { ::std::mem::transmute(m12) };
                 m12 as u64
             });
         __bindgen_bitfield_unit
@@ -1653,7 +2050,7 @@ impl MuchBitfield {
                 13usize,
                 1u8,
             >({
-                let m13: u8 = m13 as _;
+                let m13: u8 = unsafe { ::std::mem::transmute(m13) };
                 m13 as u64
             });
         __bindgen_bitfield_unit
@@ -1661,7 +2058,7 @@ impl MuchBitfield {
                 14usize,
                 1u8,
             >({
-                let m14: u8 = m14 as _;
+                let m14: u8 = unsafe { ::std::mem::transmute(m14) };
                 m14 as u64
             });
         __bindgen_bitfield_unit
@@ -1669,7 +2066,7 @@ impl MuchBitfield {
                 15usize,
                 1u8,
             >({
-                let m15: u8 = m15 as _;
+                let m15: u8 = unsafe { ::std::mem::transmute(m15) };
                 m15 as u64
             });
         __bindgen_bitfield_unit
@@ -1677,7 +2074,7 @@ impl MuchBitfield {
                 16usize,
                 1u8,
             >({
-                let m16: u8 = m16 as _;
+                let m16: u8 = unsafe { ::std::mem::transmute(m16) };
                 m16 as u64
             });
         __bindgen_bitfield_unit
@@ -1685,7 +2082,7 @@ impl MuchBitfield {
                 17usize,
                 1u8,
             >({
-                let m17: u8 = m17 as _;
+                let m17: u8 = unsafe { ::std::mem::transmute(m17) };
                 m17 as u64
             });
         __bindgen_bitfield_unit
@@ -1693,7 +2090,7 @@ impl MuchBitfield {
                 18usize,
                 1u8,
             >({
-                let m18: u8 = m18 as _;
+                let m18: u8 = unsafe { ::std::mem::transmute(m18) };
                 m18 as u64
             });
         __bindgen_bitfield_unit
@@ -1701,7 +2098,7 @@ impl MuchBitfield {
                 19usize,
                 1u8,
             >({
-                let m19: u8 = m19 as _;
+                let m19: u8 = unsafe { ::std::mem::transmute(m19) };
                 m19 as u64
             });
         __bindgen_bitfield_unit
@@ -1709,7 +2106,7 @@ impl MuchBitfield {
                 20usize,
                 1u8,
             >({
-                let m20: u8 = m20 as _;
+                let m20: u8 = unsafe { ::std::mem::transmute(m20) };
                 m20 as u64
             });
         __bindgen_bitfield_unit
@@ -1717,7 +2114,7 @@ impl MuchBitfield {
                 21usize,
                 1u8,
             >({
-                let m21: u8 = m21 as _;
+                let m21: u8 = unsafe { ::std::mem::transmute(m21) };
                 m21 as u64
             });
         __bindgen_bitfield_unit
@@ -1725,7 +2122,7 @@ impl MuchBitfield {
                 22usize,
                 1u8,
             >({
-                let m22: u8 = m22 as _;
+                let m22: u8 = unsafe { ::std::mem::transmute(m22) };
                 m22 as u64
             });
         __bindgen_bitfield_unit
@@ -1733,7 +2130,7 @@ impl MuchBitfield {
                 23usize,
                 1u8,
             >({
-                let m23: u8 = m23 as _;
+                let m23: u8 = unsafe { ::std::mem::transmute(m23) };
                 m23 as u64
             });
         __bindgen_bitfield_unit
@@ -1741,7 +2138,7 @@ impl MuchBitfield {
                 24usize,
                 1u8,
             >({
-                let m24: u8 = m24 as _;
+                let m24: u8 = unsafe { ::std::mem::transmute(m24) };
                 m24 as u64
             });
         __bindgen_bitfield_unit
@@ -1749,7 +2146,7 @@ impl MuchBitfield {
                 25usize,
                 1u8,
             >({
-                let m25: u8 = m25 as _;
+                let m25: u8 = unsafe { ::std::mem::transmute(m25) };
                 m25 as u64
             });
         __bindgen_bitfield_unit
@@ -1757,7 +2154,7 @@ impl MuchBitfield {
                 26usize,
                 1u8,
             >({
-                let m26: u8 = m26 as _;
+                let m26: u8 = unsafe { ::std::mem::transmute(m26) };
                 m26 as u64
             });
         __bindgen_bitfield_unit
@@ -1765,7 +2162,7 @@ impl MuchBitfield {
                 27usize,
                 1u8,
             >({
-                let m27: u8 = m27 as _;
+                let m27: u8 = unsafe { ::std::mem::transmute(m27) };
                 m27 as u64
             });
         __bindgen_bitfield_unit
@@ -1773,7 +2170,7 @@ impl MuchBitfield {
                 28usize,
                 1u8,
             >({
-                let m28: u8 = m28 as _;
+                let m28: u8 = unsafe { ::std::mem::transmute(m28) };
                 m28 as u64
             });
         __bindgen_bitfield_unit
@@ -1781,7 +2178,7 @@ impl MuchBitfield {
                 29usize,
                 1u8,
             >({
-                let m29: u8 = m29 as _;
+                let m29: u8 = unsafe { ::std::mem::transmute(m29) };
                 m29 as u64
             });
         __bindgen_bitfield_unit
@@ -1789,7 +2186,7 @@ impl MuchBitfield {
                 30usize,
                 1u8,
             >({
-                let m30: u8 = m30 as _;
+                let m30: u8 = unsafe { ::std::mem::transmute(m30) };
                 m30 as u64
             });
         __bindgen_bitfield_unit
@@ -1797,7 +2194,7 @@ impl MuchBitfield {
                 31usize,
                 1u8,
             >({
-                let m31: u8 = m31 as _;
+                let m31: u8 = unsafe { ::std::mem::transmute(m31) };
                 m31 as u64
             });
         __bindgen_bitfield_unit
@@ -1805,7 +2202,7 @@ impl MuchBitfield {
                 32usize,
                 1u8,
             >({
-                let m32: u8 = m32 as _;
+                let m32: u8 = unsafe { ::std::mem::transmute(m32) };
                 m32 as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -519,27 +519,39 @@ const _: () = {
 };
 impl HasBigBitfield {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn x(&self) -> i128 {
-        self._bitfield_1.get_const::<0usize, 128u8>() as u128 as _
-    }
-    #[inline]
-    pub fn set_x(&mut self, val: i128) {
-        let val: u128 = val as _;
-        self._bitfield_1.set_const::<0usize, 128u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn x_raw(this: *const Self) -> i128 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<0usize, 128u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u128 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 128u8>() as u128)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_x(&mut self, val: i128) {
+        unsafe {
+            let val: u128 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 128u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn x_raw(this: *const Self) -> i128 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    0usize,
+                    128u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_x_raw(this: *mut Self, val: i128) {
         unsafe {
-            let val: u128 = val as _;
+            let val: u128 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -549,6 +561,7 @@ impl HasBigBitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(x: i128) -> __BindgenBitfieldUnit<[u8; 16usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -556,7 +569,7 @@ impl HasBigBitfield {
                 0usize,
                 128u8,
             >({
-                let x: u128 = x as _;
+                let x: u128 = unsafe { ::std::mem::transmute(x) };
                 x as u64
             });
         __bindgen_bitfield_unit
@@ -579,27 +592,39 @@ const _: () = {
 };
 impl HasTwoBigBitfields {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn x(&self) -> i128 {
-        self._bitfield_1.get_const::<0usize, 80u8>() as u128 as _
-    }
-    #[inline]
-    pub fn set_x(&mut self, val: i128) {
-        let val: u128 = val as _;
-        self._bitfield_1.set_const::<0usize, 80u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn x_raw(this: *const Self) -> i128 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<0usize, 80u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u128 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 80u8>() as u128)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_x(&mut self, val: i128) {
+        unsafe {
+            let val: u128 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 80u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn x_raw(this: *const Self) -> i128 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    0usize,
+                    80u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_x_raw(this: *mut Self, val: i128) {
         unsafe {
-            let val: u128 = val as _;
+            let val: u128 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -609,27 +634,39 @@ impl HasTwoBigBitfields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn y(&self) -> i128 {
-        self._bitfield_1.get_const::<80usize, 48u8>() as u128 as _
-    }
-    #[inline]
-    pub fn set_y(&mut self, val: i128) {
-        let val: u128 = val as _;
-        self._bitfield_1.set_const::<80usize, 48u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn y_raw(this: *const Self) -> i128 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<80usize, 48u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u128 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<80usize, 48u8>() as u128)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_y(&mut self, val: i128) {
+        unsafe {
+            let val: u128 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<80usize, 48u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn y_raw(this: *const Self) -> i128 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    80usize,
+                    48u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u128,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_y_raw(this: *mut Self, val: i128) {
         unsafe {
-            let val: u128 = val as _;
+            let val: u128 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -639,6 +676,7 @@ impl HasTwoBigBitfields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(x: i128, y: i128) -> __BindgenBitfieldUnit<[u8; 16usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -646,7 +684,7 @@ impl HasTwoBigBitfields {
                 0usize,
                 80u8,
             >({
-                let x: u128 = x as _;
+                let x: u128 = unsafe { ::std::mem::transmute(x) };
                 x as u64
             });
         __bindgen_bitfield_unit
@@ -654,7 +692,7 @@ impl HasTwoBigBitfields {
                 80usize,
                 48u8,
             >({
-                let y: u128 = y as _;
+                let y: u128 = unsafe { ::std::mem::transmute(y) };
                 y as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -514,27 +514,39 @@ pub struct Test {
 }
 impl Test {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn x(&self) -> u64 {
-        self._bitfield_1.get_const::<0usize, 56u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_x(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<0usize, 56u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn x_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<0usize, 56u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 56u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_x(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 56u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn x_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    0usize,
+                    56u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_x_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -544,27 +556,39 @@ impl Test {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn y(&self) -> u64 {
-        self._bitfield_1.get_const::<56usize, 8u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_y(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<56usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn y_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<56usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<56usize, 8u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_y(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<56usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn y_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    56usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_y_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -574,6 +598,7 @@ impl Test {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(x: u64, y: u64) -> __BindgenBitfieldUnit<[u8; 8usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -581,7 +606,7 @@ impl Test {
                 0usize,
                 56u8,
             >({
-                let x: u64 = x as _;
+                let x: u64 = unsafe { ::std::mem::transmute(x) };
                 x as u64
             });
         __bindgen_bitfield_unit
@@ -589,7 +614,7 @@ impl Test {
                 56usize,
                 8u8,
             >({
-                let y: u64 = y as _;
+                let y: u64 = unsafe { ::std::mem::transmute(y) };
                 y as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -530,32 +530,44 @@ unsafe extern "C" {
 }
 impl Foo {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 3u8>() as u8 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn type__bindgen_bitfield_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_type__bindgen_bitfield_raw(
         this: *mut Self,
         val: ::std::os::raw::c_char,
     ) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -565,6 +577,7 @@ impl Foo {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
@@ -574,7 +587,9 @@ impl Foo {
                 0usize,
                 3u8,
             >({
-                let type__bindgen_bitfield: u8 = type__bindgen_bitfield as _;
+                let type__bindgen_bitfield: u8 = unsafe {
+                    ::std::mem::transmute(type__bindgen_bitfield)
+                };
                 type__bindgen_bitfield as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield-template.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-template.rs
@@ -524,27 +524,39 @@ impl<T> Default for foo<T> {
 }
 impl<T> foo<T> {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 8u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 8u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -554,6 +566,7 @@ impl<T> foo<T> {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -561,7 +574,7 @@ impl<T> foo<T> {
                 0usize,
                 8u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -523,27 +523,39 @@ const _: () = {
 };
 impl A {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b1_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -553,27 +565,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b2_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -583,27 +607,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b3(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b3(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b3(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b3_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b3_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -613,27 +649,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b4(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<3usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b4(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b4_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b4(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b4_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    3usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b4_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -643,27 +691,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b5(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b5(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b5_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b5(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b5_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    4usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b5_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -673,27 +733,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b6(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<5usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b6(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b6_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b6(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b6_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    5usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b6_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -703,27 +775,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b7(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<6usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b7(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b7_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b7(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b7_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    6usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b7_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -733,27 +817,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b8(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<7usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b8(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b8_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b8(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b8_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    7usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b8_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -763,27 +859,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b9(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<8usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b9(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b9_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b9(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b9_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    8usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b9_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -793,27 +901,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b10(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<9usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b10(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b10_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b10(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b10_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    9usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b10_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -823,6 +943,7 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
@@ -841,7 +962,7 @@ impl A {
                 0usize,
                 1u8,
             >({
-                let b1: u32 = b1 as _;
+                let b1: u32 = unsafe { ::std::mem::transmute(b1) };
                 b1 as u64
             });
         __bindgen_bitfield_unit
@@ -849,7 +970,7 @@ impl A {
                 1usize,
                 1u8,
             >({
-                let b2: u32 = b2 as _;
+                let b2: u32 = unsafe { ::std::mem::transmute(b2) };
                 b2 as u64
             });
         __bindgen_bitfield_unit
@@ -857,7 +978,7 @@ impl A {
                 2usize,
                 1u8,
             >({
-                let b3: u32 = b3 as _;
+                let b3: u32 = unsafe { ::std::mem::transmute(b3) };
                 b3 as u64
             });
         __bindgen_bitfield_unit
@@ -865,7 +986,7 @@ impl A {
                 3usize,
                 1u8,
             >({
-                let b4: u32 = b4 as _;
+                let b4: u32 = unsafe { ::std::mem::transmute(b4) };
                 b4 as u64
             });
         __bindgen_bitfield_unit
@@ -873,7 +994,7 @@ impl A {
                 4usize,
                 1u8,
             >({
-                let b5: u32 = b5 as _;
+                let b5: u32 = unsafe { ::std::mem::transmute(b5) };
                 b5 as u64
             });
         __bindgen_bitfield_unit
@@ -881,7 +1002,7 @@ impl A {
                 5usize,
                 1u8,
             >({
-                let b6: u32 = b6 as _;
+                let b6: u32 = unsafe { ::std::mem::transmute(b6) };
                 b6 as u64
             });
         __bindgen_bitfield_unit
@@ -889,7 +1010,7 @@ impl A {
                 6usize,
                 1u8,
             >({
-                let b7: u32 = b7 as _;
+                let b7: u32 = unsafe { ::std::mem::transmute(b7) };
                 b7 as u64
             });
         __bindgen_bitfield_unit
@@ -897,7 +1018,7 @@ impl A {
                 7usize,
                 1u8,
             >({
-                let b8: u32 = b8 as _;
+                let b8: u32 = unsafe { ::std::mem::transmute(b8) };
                 b8 as u64
             });
         __bindgen_bitfield_unit
@@ -905,7 +1026,7 @@ impl A {
                 8usize,
                 1u8,
             >({
-                let b9: u32 = b9 as _;
+                let b9: u32 = unsafe { ::std::mem::transmute(b9) };
                 b9 as u64
             });
         __bindgen_bitfield_unit
@@ -913,7 +1034,7 @@ impl A {
                 9usize,
                 1u8,
             >({
-                let b10: u32 = b10 as _;
+                let b10: u32 = unsafe { ::std::mem::transmute(b10) };
                 b10 as u64
             });
         __bindgen_bitfield_unit
@@ -932,27 +1053,39 @@ const _: () = {
 };
 impl B {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn foo(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 31u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 31u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 31u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 31u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 31u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    31u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_foo_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -962,27 +1095,39 @@ impl B {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bar(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<31usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    31usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bar_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -992,6 +1137,7 @@ impl B {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
@@ -1002,7 +1148,7 @@ impl B {
                 0usize,
                 31u8,
             >({
-                let foo: u32 = foo as _;
+                let foo: u32 = unsafe { ::std::mem::transmute(foo) };
                 foo as u64
             });
         __bindgen_bitfield_unit
@@ -1010,7 +1156,7 @@ impl B {
                 31usize,
                 1u8,
             >({
-                let bar: u8 = bar as _;
+                let bar: u8 = unsafe { ::std::mem::transmute(bar) };
                 bar as u64
             });
         __bindgen_bitfield_unit
@@ -1032,27 +1178,39 @@ const _: () = {
 };
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b1_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -1062,27 +1220,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b2_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -1092,6 +1262,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
@@ -1102,7 +1273,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let b1: u32 = b1 as _;
+                let b1: u32 = unsafe { ::std::mem::transmute(b1) };
                 b1 as u64
             });
         __bindgen_bitfield_unit
@@ -1110,7 +1281,7 @@ impl C {
                 1usize,
                 1u8,
             >({
-                let b2: u32 = b2 as _;
+                let b2: u32 = unsafe { ::std::mem::transmute(b2) };
                 b2 as u64
             });
         __bindgen_bitfield_unit
@@ -1130,27 +1301,39 @@ const _: () = {
 };
 impl Date1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    0usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nWeekDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1160,27 +1343,39 @@ impl Date1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    3usize,
+                    6u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonthDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1190,27 +1385,39 @@ impl Date1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    9usize,
+                    5u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonth_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1220,27 +1427,39 @@ impl Date1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    16usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nYear_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1250,6 +1469,7 @@ impl Date1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         nWeekDay: ::std::os::raw::c_ushort,
         nMonthDay: ::std::os::raw::c_ushort,
@@ -1262,7 +1482,7 @@ impl Date1 {
                 0usize,
                 3u8,
             >({
-                let nWeekDay: u16 = nWeekDay as _;
+                let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
                 nWeekDay as u64
             });
         __bindgen_bitfield_unit
@@ -1270,7 +1490,7 @@ impl Date1 {
                 3usize,
                 6u8,
             >({
-                let nMonthDay: u16 = nMonthDay as _;
+                let nMonthDay: u16 = unsafe { ::std::mem::transmute(nMonthDay) };
                 nMonthDay as u64
             });
         __bindgen_bitfield_unit
@@ -1278,7 +1498,7 @@ impl Date1 {
                 9usize,
                 5u8,
             >({
-                let nMonth: u16 = nMonth as _;
+                let nMonth: u16 = unsafe { ::std::mem::transmute(nMonth) };
                 nMonth as u64
             });
         __bindgen_bitfield_unit
@@ -1286,7 +1506,7 @@ impl Date1 {
                 16usize,
                 8u8,
             >({
-                let nYear: u16 = nYear as _;
+                let nYear: u16 = unsafe { ::std::mem::transmute(nYear) };
                 nYear as u64
             });
         __bindgen_bitfield_unit
@@ -1305,27 +1525,39 @@ const _: () = {
 };
 impl Date2 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nWeekDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -1335,27 +1567,39 @@ impl Date2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    3usize,
+                    6u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonthDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -1365,27 +1609,39 @@ impl Date2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    9usize,
+                    5u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonth_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -1395,27 +1651,39 @@ impl Date2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    16usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nYear_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -1425,27 +1693,39 @@ impl Date2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn byte(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<24usize, 8u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_byte(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn byte_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_byte(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn byte_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    24usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_byte_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -1455,6 +1735,7 @@ impl Date2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         nWeekDay: ::std::os::raw::c_ushort,
         nMonthDay: ::std::os::raw::c_ushort,
@@ -1468,7 +1749,7 @@ impl Date2 {
                 0usize,
                 3u8,
             >({
-                let nWeekDay: u16 = nWeekDay as _;
+                let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
                 nWeekDay as u64
             });
         __bindgen_bitfield_unit
@@ -1476,7 +1757,7 @@ impl Date2 {
                 3usize,
                 6u8,
             >({
-                let nMonthDay: u16 = nMonthDay as _;
+                let nMonthDay: u16 = unsafe { ::std::mem::transmute(nMonthDay) };
                 nMonthDay as u64
             });
         __bindgen_bitfield_unit
@@ -1484,7 +1765,7 @@ impl Date2 {
                 9usize,
                 5u8,
             >({
-                let nMonth: u16 = nMonth as _;
+                let nMonth: u16 = unsafe { ::std::mem::transmute(nMonth) };
                 nMonth as u64
             });
         __bindgen_bitfield_unit
@@ -1492,7 +1773,7 @@ impl Date2 {
                 16usize,
                 8u8,
             >({
-                let nYear: u16 = nYear as _;
+                let nYear: u16 = unsafe { ::std::mem::transmute(nYear) };
                 nYear as u64
             });
         __bindgen_bitfield_unit
@@ -1500,7 +1781,7 @@ impl Date2 {
                 24usize,
                 8u8,
             >({
-                let byte: u8 = byte as _;
+                let byte: u8 = unsafe { ::std::mem::transmute(byte) };
                 byte as u64
             });
         __bindgen_bitfield_unit
@@ -1521,27 +1802,39 @@ const _: () = {
 };
 impl Date3 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<0usize, 3u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nWeekDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nWeekDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    0usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nWeekDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1551,27 +1844,39 @@ impl Date3 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonthDay(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<3usize, 6u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<3usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 6u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonthDay(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 6u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonthDay_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    3usize,
+                    6u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonthDay_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1581,27 +1886,39 @@ impl Date3 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nMonth(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<9usize, 5u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<9usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 5u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nMonth(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 5u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nMonth_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    9usize,
+                    5u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nMonth_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1611,27 +1928,39 @@ impl Date3 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn nYear(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<16usize, 8u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_nYear(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn nYear_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    16usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_nYear_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -1641,6 +1970,7 @@ impl Date3 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         nWeekDay: ::std::os::raw::c_ushort,
         nMonthDay: ::std::os::raw::c_ushort,
@@ -1653,7 +1983,7 @@ impl Date3 {
                 0usize,
                 3u8,
             >({
-                let nWeekDay: u16 = nWeekDay as _;
+                let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
                 nWeekDay as u64
             });
         __bindgen_bitfield_unit
@@ -1661,7 +1991,7 @@ impl Date3 {
                 3usize,
                 6u8,
             >({
-                let nMonthDay: u16 = nMonthDay as _;
+                let nMonthDay: u16 = unsafe { ::std::mem::transmute(nMonthDay) };
                 nMonthDay as u64
             });
         __bindgen_bitfield_unit
@@ -1669,7 +1999,7 @@ impl Date3 {
                 9usize,
                 5u8,
             >({
-                let nMonth: u16 = nMonth as _;
+                let nMonth: u16 = unsafe { ::std::mem::transmute(nMonth) };
                 nMonth as u64
             });
         __bindgen_bitfield_unit
@@ -1677,7 +2007,7 @@ impl Date3 {
                 16usize,
                 8u8,
             >({
-                let nYear: u16 = nYear as _;
+                let nYear: u16 = unsafe { ::std::mem::transmute(nYear) };
                 nYear as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -537,17 +537,22 @@ impl Default for TaggedPtr {
 }
 impl TaggedPtr {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn tag(&self) -> MyEnum {
         unsafe {
             ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 2u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_tag(&mut self, val: MyEnum) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 2u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 2u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn tag_raw(this: *const Self) -> MyEnum {
         unsafe {
             ::std::mem::transmute(
@@ -561,9 +566,10 @@ impl TaggedPtr {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_tag_raw(this: *mut Self, val: MyEnum) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -573,27 +579,39 @@ impl TaggedPtr {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn ptr(&self) -> ::std::os::raw::c_long {
-        self._bitfield_1.get_const::<2usize, 62u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_ptr(&mut self, val: ::std::os::raw::c_long) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<2usize, 62u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn ptr_raw(this: *const Self) -> ::std::os::raw::c_long {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<2usize, 62u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 62u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_ptr(&mut self, val: ::std::os::raw::c_long) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 62u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn ptr_raw(this: *const Self) -> ::std::os::raw::c_long {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    2usize,
+                    62u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_ptr_raw(this: *mut Self, val: ::std::os::raw::c_long) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -603,6 +621,7 @@ impl TaggedPtr {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         tag: MyEnum,
         ptr: ::std::os::raw::c_long,
@@ -613,7 +632,7 @@ impl TaggedPtr {
                 0usize,
                 2u8,
             >({
-                let tag: u32 = tag as _;
+                let tag: u32 = unsafe { ::std::mem::transmute(tag) };
                 tag as u64
             });
         __bindgen_bitfield_unit
@@ -621,7 +640,7 @@ impl TaggedPtr {
                 2usize,
                 62u8,
             >({
-                let ptr: u64 = ptr as _;
+                let ptr: u64 = unsafe { ::std::mem::transmute(ptr) };
                 ptr as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -523,27 +523,39 @@ const _: () = {
 };
 impl mach_msg_type_descriptor_t {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn pad3(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 24u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_pad3(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 24u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn pad3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 24u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 24u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_pad3(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 24u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn pad3_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    24u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_pad3_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -553,27 +565,39 @@ impl mach_msg_type_descriptor_t {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn type_(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<24usize, 8u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_type(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn type__raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_type(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn type__raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    24usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_type_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -583,6 +607,7 @@ impl mach_msg_type_descriptor_t {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         pad3: ::std::os::raw::c_uint,
         type_: ::std::os::raw::c_uint,
@@ -593,7 +618,7 @@ impl mach_msg_type_descriptor_t {
                 0usize,
                 24u8,
             >({
-                let pad3: u32 = pad3 as _;
+                let pad3: u32 = unsafe { ::std::mem::transmute(pad3) };
                 pad3 as u64
             });
         __bindgen_bitfield_unit
@@ -601,7 +626,7 @@ impl mach_msg_type_descriptor_t {
                 24usize,
                 8u8,
             >({
-                let type_: u32 = type_ as _;
+                let type_: u32 = unsafe { ::std::mem::transmute(type_) };
                 type_ as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
@@ -536,27 +536,39 @@ impl Default for A {
 }
 impl A {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn firmness(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_firmness(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn firmness_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_firmness(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn firmness_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_firmness_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -566,27 +578,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn color(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_color(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn color_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_color(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn color_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_color_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -596,27 +620,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn weedsBonus(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<8usize, 3u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_weedsBonus(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<8usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn weedsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<8usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 3u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_weedsBonus(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn weedsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    8usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_weedsBonus_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -626,27 +662,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn pestsBonus(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<11usize, 3u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_pestsBonus(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<11usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn pestsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<11usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 3u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_pestsBonus(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<11usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn pestsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    11usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_pestsBonus_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -656,27 +704,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn size(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<14usize, 10u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_size(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<14usize, 10u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn size_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<14usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 10u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_size(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<14usize, 10u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn size_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    14usize,
+                    10u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_size_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -686,6 +746,7 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         firmness: ::std::os::raw::c_uchar,
         color: ::std::os::raw::c_uchar,
@@ -699,7 +760,7 @@ impl A {
                 0usize,
                 4u8,
             >({
-                let firmness: u8 = firmness as _;
+                let firmness: u8 = unsafe { ::std::mem::transmute(firmness) };
                 firmness as u64
             });
         __bindgen_bitfield_unit
@@ -707,7 +768,7 @@ impl A {
                 4usize,
                 4u8,
             >({
-                let color: u8 = color as _;
+                let color: u8 = unsafe { ::std::mem::transmute(color) };
                 color as u64
             });
         __bindgen_bitfield_unit
@@ -715,7 +776,7 @@ impl A {
                 8usize,
                 3u8,
             >({
-                let weedsBonus: u16 = weedsBonus as _;
+                let weedsBonus: u16 = unsafe { ::std::mem::transmute(weedsBonus) };
                 weedsBonus as u64
             });
         __bindgen_bitfield_unit
@@ -723,7 +784,7 @@ impl A {
                 11usize,
                 3u8,
             >({
-                let pestsBonus: u16 = pestsBonus as _;
+                let pestsBonus: u16 = unsafe { ::std::mem::transmute(pestsBonus) };
                 pestsBonus as u64
             });
         __bindgen_bitfield_unit
@@ -731,33 +792,45 @@ impl A {
                 14usize,
                 10u8,
             >({
-                let size: u16 = size as _;
+                let size: u16 = unsafe { ::std::mem::transmute(size) };
                 size as u64
             });
         __bindgen_bitfield_unit
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn minYield(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_2.get_const::<0usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_minYield(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn minYield_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_minYield(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn minYield_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_minYield_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -767,27 +840,39 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn waterBonus(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_2.get_const::<4usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_waterBonus(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn waterBonus_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<4usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_waterBonus(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn waterBonus_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_waterBonus_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -797,6 +882,7 @@ impl A {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_2(
         minYield: ::std::os::raw::c_uchar,
         waterBonus: ::std::os::raw::c_uchar,
@@ -807,7 +893,7 @@ impl A {
                 0usize,
                 4u8,
             >({
-                let minYield: u8 = minYield as _;
+                let minYield: u8 = unsafe { ::std::mem::transmute(minYield) };
                 minYield as u64
             });
         __bindgen_bitfield_unit
@@ -815,7 +901,7 @@ impl A {
                 4usize,
                 4u8,
             >({
-                let waterBonus: u8 = waterBonus as _;
+                let waterBonus: u8 = unsafe { ::std::mem::transmute(waterBonus) };
                 waterBonus as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -518,27 +518,39 @@ const _: () = {
 };
 impl Struct {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -548,27 +560,39 @@ impl Struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -578,27 +602,39 @@ impl Struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn c(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<2usize, 6u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 6u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<2usize, 6u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 6u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 6u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    2usize,
+                    6u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -608,27 +644,39 @@ impl Struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn d(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<8usize, 16u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<8usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<8usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 16u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    8usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_d_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -638,27 +686,39 @@ impl Struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn e(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<24usize, 8u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_e(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<24usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 8u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_e(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    24usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_e_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -668,6 +728,7 @@ impl Struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_uchar,
         b: ::std::os::raw::c_uchar,
@@ -681,7 +742,7 @@ impl Struct {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -689,7 +750,7 @@ impl Struct {
                 1usize,
                 1u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit
@@ -697,7 +758,7 @@ impl Struct {
                 2usize,
                 6u8,
             >({
-                let c: u8 = c as _;
+                let c: u8 = unsafe { ::std::mem::transmute(c) };
                 c as u64
             });
         __bindgen_bitfield_unit
@@ -705,7 +766,7 @@ impl Struct {
                 8usize,
                 16u8,
             >({
-                let d: u16 = d as _;
+                let d: u16 = unsafe { ::std::mem::transmute(d) };
                 d as u64
             });
         __bindgen_bitfield_unit
@@ -713,7 +774,7 @@ impl Struct {
                 24usize,
                 8u8,
             >({
-                let e: u8 = e as _;
+                let e: u8 = unsafe { ::std::mem::transmute(e) };
                 e as u64
             });
         __bindgen_bitfield_unit
@@ -732,27 +793,39 @@ const _: () = {
 };
 impl Inner {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<0usize, 16u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -762,27 +835,39 @@ impl Inner {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<16usize, 16u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<16usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<16usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 16u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    16usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -792,6 +877,7 @@ impl Inner {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_ushort,
         b: ::std::os::raw::c_ushort,
@@ -802,7 +888,7 @@ impl Inner {
                 0usize,
                 16u8,
             >({
-                let a: u16 = a as _;
+                let a: u16 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -810,7 +896,7 @@ impl Inner {
                 16usize,
                 16u8,
             >({
-                let b: u16 = b as _;
+                let b: u16 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
@@ -18,27 +18,39 @@ const _: () = {
 };
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b1(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b1_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b1_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -48,27 +60,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b2(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b2(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b2_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b2_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -78,6 +102,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
@@ -88,7 +113,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let b1: u32 = b1 as _;
+                let b1: u32 = unsafe { ::std::mem::transmute(b1) };
                 b1 as u64
             });
         __bindgen_bitfield_unit
@@ -96,7 +121,7 @@ impl C {
                 1usize,
                 1u8,
             >({
-                let b2: u32 = b2 as _;
+                let b2: u32 = unsafe { ::std::mem::transmute(b2) };
                 b2 as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -519,27 +519,39 @@ pub struct Color {
 }
 impl Color {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) fn r(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub(crate) fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub(crate) unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) fn set_r(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) unsafe fn set_r_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -549,27 +561,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) fn g(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub(crate) fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub(crate) unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) fn set_g(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) unsafe fn set_g_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -579,27 +603,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) fn b(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub(crate) fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub(crate) unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) fn set_b(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub(crate) unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -609,6 +645,7 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub(crate) fn new_bitfield_1(
         r: ::std::os::raw::c_char,
         g: ::std::os::raw::c_char,
@@ -620,7 +657,7 @@ impl Color {
                 0usize,
                 1u8,
             >({
-                let r: u8 = r as _;
+                let r: u8 = unsafe { ::std::mem::transmute(r) };
                 r as u64
             });
         __bindgen_bitfield_unit
@@ -628,7 +665,7 @@ impl Color {
                 1usize,
                 1u8,
             >({
-                let g: u8 = g as _;
+                let g: u8 = unsafe { ::std::mem::transmute(g) };
                 g as u64
             });
         __bindgen_bitfield_unit
@@ -636,7 +673,7 @@ impl Color {
                 2usize,
                 1u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -519,27 +519,39 @@ pub struct Color {
 }
 impl Color {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn r(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_r(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_r_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -549,27 +561,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn g(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_g(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_g_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -579,27 +603,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn b(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_b(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -609,6 +645,7 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         r: ::std::os::raw::c_char,
         g: ::std::os::raw::c_char,
@@ -620,7 +657,7 @@ impl Color {
                 0usize,
                 1u8,
             >({
-                let r: u8 = r as _;
+                let r: u8 = unsafe { ::std::mem::transmute(r) };
                 r as u64
             });
         __bindgen_bitfield_unit
@@ -628,7 +665,7 @@ impl Color {
                 1usize,
                 1u8,
             >({
-                let g: u8 = g as _;
+                let g: u8 = unsafe { ::std::mem::transmute(g) };
                 g as u64
             });
         __bindgen_bitfield_unit
@@ -636,7 +673,7 @@ impl Color {
                 2usize,
                 1u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -519,27 +519,39 @@ pub struct Color {
 }
 impl Color {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn r(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_r(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_r(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn r_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_r_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -549,27 +561,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn g(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_g(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_g(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_g_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -579,27 +603,39 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -609,6 +645,7 @@ impl Color {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         r: ::std::os::raw::c_char,
         g: ::std::os::raw::c_char,
@@ -620,7 +657,7 @@ impl Color {
                 0usize,
                 1u8,
             >({
-                let r: u8 = r as _;
+                let r: u8 = unsafe { ::std::mem::transmute(r) };
                 r as u64
             });
         __bindgen_bitfield_unit
@@ -628,7 +665,7 @@ impl Color {
                 1usize,
                 1u8,
             >({
-                let g: u8 = g as _;
+                let g: u8 = unsafe { ::std::mem::transmute(g) };
                 g as u64
             });
         __bindgen_bitfield_unit
@@ -636,7 +673,7 @@ impl Color {
                 2usize,
                 1u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -545,32 +545,44 @@ impl Default for Foo {
 }
 impl Foo {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 3u8>() as u8 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 3u8>() as u8)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 3u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn type__bindgen_bitfield_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_type__bindgen_bitfield_raw(
         this: *mut Self,
         val: ::std::os::raw::c_char,
     ) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -580,6 +592,7 @@ impl Foo {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
@@ -589,7 +602,9 @@ impl Foo {
                 0usize,
                 3u8,
             >({
-                let type__bindgen_bitfield: u8 = type__bindgen_bitfield as _;
+                let type__bindgen_bitfield: u8 = unsafe {
+                    ::std::mem::transmute(type__bindgen_bitfield)
+                };
                 type__bindgen_bitfield as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
@@ -529,27 +529,39 @@ impl Default for C {
 }
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -559,27 +571,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -589,6 +613,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -596,7 +621,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -604,7 +629,7 @@ impl C {
                 1usize,
                 7u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -532,27 +532,39 @@ impl Default for C {
 }
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::core::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::core::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> bool {
+        unsafe {
+            ::core::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::core::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::core::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -562,27 +574,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 7u8>(::core::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::core::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::core::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::core::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    7u8,
+                >(::core::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::core::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -592,6 +616,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -599,7 +624,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::core::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -607,7 +632,7 @@ impl C {
                 1usize,
                 7u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::core::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -529,27 +529,39 @@ impl Default for C {
 }
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -559,27 +571,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -589,6 +613,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -596,7 +621,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -604,7 +629,7 @@ impl C {
                 1usize,
                 7u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -529,27 +529,39 @@ impl Default for C {
 }
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -559,27 +571,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -589,6 +613,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -596,7 +621,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -604,7 +629,7 @@ impl C {
                 1usize,
                 7u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -514,6 +514,7 @@ pub struct WithBitfield {
 }
 impl WithBitfield {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -527,6 +528,7 @@ pub struct WithBitfieldAndAttrPacked {
 }
 impl WithBitfieldAndAttrPacked {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -540,6 +542,7 @@ pub struct WithBitfieldAndPacked {
 }
 impl WithBitfieldAndPacked {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/field-rename-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-rename-callback.rs
@@ -531,32 +531,44 @@ const _: () = {
 };
 impl RenameMe {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bitfield_less_ugly_name(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_bitfield_less_ugly_name(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn bitfield_less_ugly_name_raw(
         this: *const Self,
     ) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bitfield_less_ugly_name_raw(
         this: *mut Self,
         val: ::std::os::raw::c_int,
     ) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -566,30 +578,42 @@ impl RenameMe {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bitfield_better_name(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bitfield_better_name(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bitfield_better_name_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bitfield_better_name(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bitfield_better_name_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bitfield_better_name_raw(
         this: *mut Self,
         val: ::std::os::raw::c_int,
     ) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -599,6 +623,7 @@ impl RenameMe {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         bitfield_less_ugly_name: ::std::os::raw::c_int,
         bitfield_better_name: ::std::os::raw::c_int,
@@ -609,7 +634,9 @@ impl RenameMe {
                 0usize,
                 1u8,
             >({
-                let bitfield_less_ugly_name: u32 = bitfield_less_ugly_name as _;
+                let bitfield_less_ugly_name: u32 = unsafe {
+                    ::std::mem::transmute(bitfield_less_ugly_name)
+                };
                 bitfield_less_ugly_name as u64
             });
         __bindgen_bitfield_unit
@@ -617,7 +644,9 @@ impl RenameMe {
                 1usize,
                 1u8,
             >({
-                let bitfield_better_name: u32 = bitfield_better_name as _;
+                let bitfield_better_name: u32 = unsafe {
+                    ::std::mem::transmute(bitfield_better_name)
+                };
                 bitfield_better_name as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -525,27 +525,39 @@ const _: () = {
 };
 impl my_struct {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -555,27 +567,39 @@ impl my_struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn private_d(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    fn set_private_d(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn private_d_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_private_d(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn private_d_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_private_d_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -585,6 +609,7 @@ impl my_struct {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         c: ::std::os::raw::c_int,
         private_d: ::std::os::raw::c_int,
@@ -595,7 +620,7 @@ impl my_struct {
                 0usize,
                 1u8,
             >({
-                let c: u32 = c as _;
+                let c: u32 = unsafe { ::std::mem::transmute(c) };
                 c as u64
             });
         __bindgen_bitfield_unit
@@ -603,7 +628,7 @@ impl my_struct {
                 1usize,
                 1u8,
             >({
-                let private_d: u32 = private_d as _;
+                let private_d: u32 = unsafe { ::std::mem::transmute(private_d) };
                 private_d as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -520,27 +520,39 @@ const _: () = {
 };
 impl my_struct1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn a(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_a(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -550,6 +562,7 @@ impl my_struct1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(a: ::std::os::raw::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -557,7 +570,7 @@ impl my_struct1 {
                 0usize,
                 1u8,
             >({
-                let a: u32 = a as _;
+                let a: u32 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -577,27 +590,39 @@ const _: () = {
 };
 impl my_struct2 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -607,6 +632,7 @@ impl my_struct2 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_int,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
@@ -616,7 +642,7 @@ impl my_struct2 {
                 0usize,
                 1u8,
             >({
-                let a: u32 = a as _;
+                let a: u32 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -559,27 +559,39 @@ impl Default for foo {
 }
 impl foo {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_char {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_char) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_char {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_char) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_char {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_char) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -589,6 +601,7 @@ impl foo {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_char,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
@@ -598,7 +611,7 @@ impl foo {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -518,6 +518,7 @@ const _: () = {
 };
 impl S2 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 2usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -518,6 +518,7 @@ const _: () = {
 };
 impl S1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 3usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -528,27 +528,39 @@ const _: () = {
 };
 impl V56AMDY {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MADZ(&self) -> U16 {
-        self._bitfield_1.get_const::<0usize, 10u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MADZ(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 10u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MADZ_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 10u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MADZ(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 10u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MADZ_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    10u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MADZ_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -558,27 +570,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MAI0(&self) -> U16 {
-        self._bitfield_1.get_const::<10usize, 2u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MAI0(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<10usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MAI0_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<10usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 2u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MAI0(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<10usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MAI0_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    10usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MAI0_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -588,27 +612,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MAI1(&self) -> U16 {
-        self._bitfield_1.get_const::<12usize, 2u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MAI1(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<12usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MAI1_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<12usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 2u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MAI1(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<12usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MAI1_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    12usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MAI1_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -618,27 +654,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MAI2(&self) -> U16 {
-        self._bitfield_1.get_const::<14usize, 2u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MAI2(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<14usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MAI2_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<14usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 2u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MAI2(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<14usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MAI2_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    14usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MAI2_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -648,6 +696,7 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         MADZ: U16,
         MAI0: U16,
@@ -660,7 +709,7 @@ impl V56AMDY {
                 0usize,
                 10u8,
             >({
-                let MADZ: u16 = MADZ as _;
+                let MADZ: u16 = unsafe { ::std::mem::transmute(MADZ) };
                 MADZ as u64
             });
         __bindgen_bitfield_unit
@@ -668,7 +717,7 @@ impl V56AMDY {
                 10usize,
                 2u8,
             >({
-                let MAI0: u16 = MAI0 as _;
+                let MAI0: u16 = unsafe { ::std::mem::transmute(MAI0) };
                 MAI0 as u64
             });
         __bindgen_bitfield_unit
@@ -676,7 +725,7 @@ impl V56AMDY {
                 12usize,
                 2u8,
             >({
-                let MAI1: u16 = MAI1 as _;
+                let MAI1: u16 = unsafe { ::std::mem::transmute(MAI1) };
                 MAI1 as u64
             });
         __bindgen_bitfield_unit
@@ -684,33 +733,45 @@ impl V56AMDY {
                 14usize,
                 2u8,
             >({
-                let MAI2: u16 = MAI2 as _;
+                let MAI2: u16 = unsafe { ::std::mem::transmute(MAI2) };
                 MAI2 as u64
             });
         __bindgen_bitfield_unit
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MATH(&self) -> U16 {
-        self._bitfield_2.get_const::<0usize, 10u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MATH(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_2.set_const::<0usize, 10u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MATH_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<0usize, 10u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 10u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MATH(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<0usize, 10u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MATH_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    0usize,
+                    10u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MATH_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -720,27 +781,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MATE(&self) -> U16 {
-        self._bitfield_2.get_const::<10usize, 4u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MATE(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_2.set_const::<10usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MATE_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<10usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<10usize, 4u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MATE(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<10usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MATE_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    10usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MATE_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -750,27 +823,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MATW(&self) -> U16 {
-        self._bitfield_2.get_const::<14usize, 2u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_MATW(&mut self, val: U16) {
-        let val: u16 = val as _;
-        self._bitfield_2.set_const::<14usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MATW_raw(this: *const Self) -> U16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<14usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<14usize, 2u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MATW(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<14usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MATW_raw(this: *const Self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    14usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MATW_raw(this: *mut Self, val: U16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -780,27 +865,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MASW(&self) -> U8 {
-        self._bitfield_2.get_const::<16usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_MASW(&mut self, val: U8) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<16usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MASW_raw(this: *const Self) -> U8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<16usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<16usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MASW(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<16usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MASW_raw(this: *const Self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    16usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MASW_raw(this: *mut Self, val: U8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -810,27 +907,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MABW(&self) -> U8 {
-        self._bitfield_2.get_const::<20usize, 3u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_MABW(&mut self, val: U8) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<20usize, 3u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MABW_raw(this: *const Self) -> U8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<20usize, 3u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<20usize, 3u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MABW(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<20usize, 3u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MABW_raw(this: *const Self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    20usize,
+                    3u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MABW_raw(this: *mut Self, val: U8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -840,27 +949,39 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn MAXN(&self) -> U8 {
-        self._bitfield_2.get_const::<23usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_MAXN(&mut self, val: U8) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<23usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn MAXN_raw(this: *const Self) -> U8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<23usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_MAXN(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<23usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn MAXN_raw(this: *const Self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    23usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_MAXN_raw(this: *mut Self, val: U8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -870,6 +991,7 @@ impl V56AMDY {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_2(
         MATH: U16,
         MATE: U16,
@@ -884,7 +1006,7 @@ impl V56AMDY {
                 0usize,
                 10u8,
             >({
-                let MATH: u16 = MATH as _;
+                let MATH: u16 = unsafe { ::std::mem::transmute(MATH) };
                 MATH as u64
             });
         __bindgen_bitfield_unit
@@ -892,7 +1014,7 @@ impl V56AMDY {
                 10usize,
                 4u8,
             >({
-                let MATE: u16 = MATE as _;
+                let MATE: u16 = unsafe { ::std::mem::transmute(MATE) };
                 MATE as u64
             });
         __bindgen_bitfield_unit
@@ -900,7 +1022,7 @@ impl V56AMDY {
                 14usize,
                 2u8,
             >({
-                let MATW: u16 = MATW as _;
+                let MATW: u16 = unsafe { ::std::mem::transmute(MATW) };
                 MATW as u64
             });
         __bindgen_bitfield_unit
@@ -908,7 +1030,7 @@ impl V56AMDY {
                 16usize,
                 4u8,
             >({
-                let MASW: u8 = MASW as _;
+                let MASW: u8 = unsafe { ::std::mem::transmute(MASW) };
                 MASW as u64
             });
         __bindgen_bitfield_unit
@@ -916,7 +1038,7 @@ impl V56AMDY {
                 20usize,
                 3u8,
             >({
-                let MABW: u8 = MABW as _;
+                let MABW: u8 = unsafe { ::std::mem::transmute(MABW) };
                 MABW as u64
             });
         __bindgen_bitfield_unit
@@ -924,7 +1046,7 @@ impl V56AMDY {
                 23usize,
                 1u8,
             >({
-                let MAXN: u8 = MAXN as _;
+                let MAXN: u8 = unsafe { ::std::mem::transmute(MAXN) };
                 MAXN as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/issue-3454-enum-newtype-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3454-enum-newtype-bitfield.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#![cfg(not(target_os = "windows"))]
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage> {
@@ -507,226 +506,149 @@ impl<const N: usize> __BindgenBitfieldUnit<[u8; N]> {
         }
     }
 }
+impl pipe_resource_usage {
+    pub const PIPE_USAGE_DEFAULT: pipe_resource_usage = pipe_resource_usage(0);
+    pub const PIPE_USAGE_IMMUTABLE: pipe_resource_usage = pipe_resource_usage(1);
+    pub const PIPE_USAGE_DYNAMIC: pipe_resource_usage = pipe_resource_usage(2);
+    pub const PIPE_USAGE_STREAM: pipe_resource_usage = pipe_resource_usage(3);
+    pub const PIPE_USAGE_STAGING: pipe_resource_usage = pipe_resource_usage(4);
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct pipe_resource_usage(pub ::std::os::raw::c_uint);
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct Foo {
-    pub _bindgen_align: [u64; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
+#[derive(Debug, Copy, Clone)]
+pub struct pipe_resource {
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Foo"][::std::mem::size_of::<Foo>() - 32usize];
-    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+    ["Size of pipe_resource"][::std::mem::size_of::<pipe_resource>() - 4usize];
+    ["Alignment of pipe_resource"][::std::mem::align_of::<pipe_resource>() - 4usize];
 };
-impl Foo {
+impl Default for pipe_resource {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl pipe_resource {
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub fn m_bitfield(&self) -> ::std::os::raw::c_ulong {
+    pub fn compression_rate(&self) -> ::std::os::raw::c_uint {
         unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 64u8>() as u64)
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub fn set_m_bitfield(&mut self, val: ::std::os::raw::c_ulong) {
+    pub fn set_compression_rate(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set_const::<0usize, 64u8>(val as u64)
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub unsafe fn m_bitfield_raw(this: *const Self) -> ::std::os::raw::c_ulong {
+    pub unsafe fn compression_rate_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 32usize],
+                    [u8; 1usize],
                 >>::raw_get_const::<
                     0usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
             )
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub unsafe fn set_m_bitfield_raw(this: *mut Self, val: ::std::os::raw::c_ulong) {
+    pub unsafe fn set_compression_rate_raw(
+        this: *mut Self,
+        val: ::std::os::raw::c_uint,
+    ) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 32usize],
+                [u8; 1usize],
             >>::raw_set_const::<
                 0usize,
-                64u8,
+                4u8,
             >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub fn m_bar(&self) -> ::std::os::raw::c_ulong {
+    pub fn usage(&self) -> pipe_resource_usage {
         unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<64usize, 64u8>() as u64)
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub fn set_m_bar(&mut self, val: ::std::os::raw::c_ulong) {
+    pub fn set_usage(&mut self, val: pipe_resource_usage) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set_const::<64usize, 64u8>(val as u64)
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub unsafe fn m_bar_raw(this: *const Self) -> ::std::os::raw::c_ulong {
+    pub unsafe fn usage_raw(this: *const Self) -> pipe_resource_usage {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 32usize],
+                    [u8; 1usize],
                 >>::raw_get_const::<
-                    64usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
             )
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
-    pub unsafe fn set_m_bar_raw(this: *mut Self, val: ::std::os::raw::c_ulong) {
+    pub unsafe fn set_usage_raw(this: *mut Self, val: pipe_resource_usage) {
         unsafe {
-            let val: u64 = ::std::mem::transmute(val);
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 32usize],
+                [u8; 1usize],
             >>::raw_set_const::<
-                64usize,
-                64u8,
-            >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub fn foo(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<128usize, 1u8>() as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub fn set_foo(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set_const::<128usize, 1u8>(val as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    128usize,
-                    1u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub unsafe fn set_foo_raw(this: *mut Self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<
-                [u8; 32usize],
-            >>::raw_set_const::<
-                128usize,
-                1u8,
-            >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub fn bar(&self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(self._bitfield_1.get_const::<192usize, 64u8>() as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub fn set_bar(&mut self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            self._bitfield_1.set_const::<192usize, 64u8>(val as u64)
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_ulong {
-        unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 32usize],
-                >>::raw_get_const::<
-                    192usize,
-                    64u8,
-                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
-            )
-        }
-    }
-    #[inline]
-    #[allow(unnecessary_transmutes)]
-    pub unsafe fn set_bar_raw(this: *mut Self, val: ::std::os::raw::c_ulong) {
-        unsafe {
-            let val: u64 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<
-                [u8; 32usize],
-            >>::raw_set_const::<
-                192usize,
-                64u8,
+                4usize,
+                4u8,
             >(::std::ptr::addr_of_mut!((*this)._bitfield_1), val as u64)
         }
     }
     #[inline]
     #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
-        m_bitfield: ::std::os::raw::c_ulong,
-        m_bar: ::std::os::raw::c_ulong,
-        foo: ::std::os::raw::c_ulong,
-        bar: ::std::os::raw::c_ulong,
-    ) -> __BindgenBitfieldUnit<[u8; 32usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 32usize]> = Default::default();
+        compression_rate: ::std::os::raw::c_uint,
+        usage: pipe_resource_usage,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
             .set_const::<
                 0usize,
-                64u8,
+                4u8,
             >({
-                let m_bitfield: u64 = unsafe { ::std::mem::transmute(m_bitfield) };
-                m_bitfield as u64
+                let compression_rate: u32 = unsafe {
+                    ::std::mem::transmute(compression_rate)
+                };
+                compression_rate as u64
             });
         __bindgen_bitfield_unit
             .set_const::<
-                64usize,
-                64u8,
+                4usize,
+                4u8,
             >({
-                let m_bar: u64 = unsafe { ::std::mem::transmute(m_bar) };
-                m_bar as u64
-            });
-        __bindgen_bitfield_unit
-            .set_const::<
-                128usize,
-                1u8,
-            >({
-                let foo: u64 = unsafe { ::std::mem::transmute(foo) };
-                foo as u64
-            });
-        __bindgen_bitfield_unit
-            .set_const::<
-                192usize,
-                64u8,
-            >({
-                let bar: u64 = unsafe { ::std::mem::transmute(bar) };
-                bar as u64
+                let usage: u32 = unsafe { ::std::mem::transmute(usage) };
+                usage as u64
             });
         __bindgen_bitfield_unit
     }

--- a/bindgen-tests/tests/expectations/tests/issue-743.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-743.rs
@@ -532,27 +532,39 @@ impl Default for S {
 }
 impl S {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn u(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 16u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_u(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn u_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_u(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn u_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_u_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -562,6 +574,7 @@ impl S {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         u: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
@@ -571,7 +584,7 @@ impl S {
                 0usize,
                 16u8,
             >({
-                let u: u32 = u as _;
+                let u: u32 = unsafe { ::std::mem::transmute(u) };
                 u as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -519,27 +519,39 @@ const _: () = {
 };
 impl capabilities {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_1(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_1(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_1_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_1(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_1_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_1_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -549,27 +561,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_2(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_2(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_2(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_2_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_2_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -579,27 +603,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_3(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_3(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_3_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_3(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_3_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_3_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -609,27 +645,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_4(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<3usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_4(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_4_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_4(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_4_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    3usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_4_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -639,27 +687,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_5(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_5(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_5_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_5(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_5_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    4usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_5_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -669,27 +729,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_6(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<5usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_6(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_6_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_6(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_6_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    5usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_6_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -699,27 +771,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_7(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<6usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_7(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_7_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_7(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_7_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    6usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_7_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -729,27 +813,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_8(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<7usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_8(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_8_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_8(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_8_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    7usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_8_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -759,27 +855,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_9(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<8usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_9(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_9_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_9(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_9_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    8usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_9_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -789,27 +897,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_10(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<9usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_10(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_10_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<9usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_10(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_10_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    9usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_10_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -819,27 +939,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_11(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<10usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_11(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_11_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<10usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<10usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_11(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<10usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_11_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    10usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_11_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -849,27 +981,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_12(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<11usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_12(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_12_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<11usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<11usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_12(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<11usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_12_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    11usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_12_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -879,27 +1023,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_13(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<12usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_13(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_13_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<12usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_13(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<12usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_13_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    12usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_13_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -909,27 +1065,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_14(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<13usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_14(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_14_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<13usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<13usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_14(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<13usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_14_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    13usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_14_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -939,27 +1107,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_15(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<14usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_15(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_15_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<14usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<14usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_15(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<14usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_15_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    14usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_15_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -969,27 +1149,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_16(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<15usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_16(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_16_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<15usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<15usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_16(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<15usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_16_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    15usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_16_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -999,27 +1191,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_17(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<16usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_17(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_17_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<16usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_17(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_17_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    16usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_17_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1029,27 +1233,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_18(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<17usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_18(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_18_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<17usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<17usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_18(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<17usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_18_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    17usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_18_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1059,27 +1275,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_19(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<18usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_19(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_19_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<18usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<18usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_19(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<18usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_19_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    18usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_19_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1089,27 +1317,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_20(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<19usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_20(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_20_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<19usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<19usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_20(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<19usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_20_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    19usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_20_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1119,27 +1359,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_21(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<20usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_21(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_21_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<20usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_21(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<20usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_21_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    20usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_21_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1149,27 +1401,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_22(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<21usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_22(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_22_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<21usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<21usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_22(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<21usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_22_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    21usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_22_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1179,27 +1443,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_23(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<22usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_23(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_23_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<22usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<22usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_23(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<22usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_23_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    22usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_23_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1209,27 +1485,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_24(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<23usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_24(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_24_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<23usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<23usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_24(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<23usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_24_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    23usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_24_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1239,27 +1527,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_25(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<24usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_25(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_25_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<24usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_25(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_25_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    24usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_25_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1269,27 +1569,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_26(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<25usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_26(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_26_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<25usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<25usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_26(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<25usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_26_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    25usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_26_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1299,27 +1611,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_27(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<26usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_27(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_27_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<26usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<26usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_27(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<26usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_27_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    26usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_27_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1329,27 +1653,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_28(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<27usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_28(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_28_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<27usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<27usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_28(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<27usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_28_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    27usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_28_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1359,27 +1695,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_29(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<28usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_29(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_29_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<28usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<28usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_29(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<28usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_29_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    28usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_29_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1389,27 +1737,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_30(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<29usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_30(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_30_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<29usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<29usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_30(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<29usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_30_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    29usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_30_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1419,27 +1779,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_31(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<30usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_31(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_31_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<30usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<30usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_31(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<30usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_31_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    30usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_31_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1449,27 +1821,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_32(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<31usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_32(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_32_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<31usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<31usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_32(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<31usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_32_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    31usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_32_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1479,27 +1863,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_33(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<32usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_33(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_33_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<32usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_33(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<32usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_33_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    32usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_33_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1509,27 +1905,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_34(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<33usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_34(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<33usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_34_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<33usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<33usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_34(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<33usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_34_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    33usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_34_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1539,27 +1947,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_35(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<34usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_35(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<34usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_35_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<34usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<34usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_35(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<34usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_35_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    34usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_35_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1569,27 +1989,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_36(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<35usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_36(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<35usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_36_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<35usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<35usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_36(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<35usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_36_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    35usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_36_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1599,27 +2031,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_37(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<36usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_37(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<36usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_37_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<36usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<36usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_37(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<36usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_37_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    36usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_37_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1629,27 +2073,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_38(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<37usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_38(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<37usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_38_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<37usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<37usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_38(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<37usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_38_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    37usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_38_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1659,27 +2115,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_39(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<38usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_39(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<38usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_39_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<38usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<38usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_39(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<38usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_39_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    38usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_39_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1689,27 +2157,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_40(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<39usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_40(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<39usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_40_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<39usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<39usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_40(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<39usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_40_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    39usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_40_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1719,27 +2199,39 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bit_41(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<40usize, 1u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bit_41(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<40usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bit_41_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 16usize],
-            >>::raw_get_const::<40usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<40usize, 1u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bit_41(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<40usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bit_41_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 16usize],
+                >>::raw_get_const::<
+                    40usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bit_41_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 16usize],
             >>::raw_set_const::<
@@ -1749,6 +2241,7 @@ impl capabilities {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         bit_1: ::std::os::raw::c_uint,
         bit_2: ::std::os::raw::c_uint,
@@ -1798,7 +2291,7 @@ impl capabilities {
                 0usize,
                 1u8,
             >({
-                let bit_1: u32 = bit_1 as _;
+                let bit_1: u32 = unsafe { ::std::mem::transmute(bit_1) };
                 bit_1 as u64
             });
         __bindgen_bitfield_unit
@@ -1806,7 +2299,7 @@ impl capabilities {
                 1usize,
                 1u8,
             >({
-                let bit_2: u32 = bit_2 as _;
+                let bit_2: u32 = unsafe { ::std::mem::transmute(bit_2) };
                 bit_2 as u64
             });
         __bindgen_bitfield_unit
@@ -1814,7 +2307,7 @@ impl capabilities {
                 2usize,
                 1u8,
             >({
-                let bit_3: u32 = bit_3 as _;
+                let bit_3: u32 = unsafe { ::std::mem::transmute(bit_3) };
                 bit_3 as u64
             });
         __bindgen_bitfield_unit
@@ -1822,7 +2315,7 @@ impl capabilities {
                 3usize,
                 1u8,
             >({
-                let bit_4: u32 = bit_4 as _;
+                let bit_4: u32 = unsafe { ::std::mem::transmute(bit_4) };
                 bit_4 as u64
             });
         __bindgen_bitfield_unit
@@ -1830,7 +2323,7 @@ impl capabilities {
                 4usize,
                 1u8,
             >({
-                let bit_5: u32 = bit_5 as _;
+                let bit_5: u32 = unsafe { ::std::mem::transmute(bit_5) };
                 bit_5 as u64
             });
         __bindgen_bitfield_unit
@@ -1838,7 +2331,7 @@ impl capabilities {
                 5usize,
                 1u8,
             >({
-                let bit_6: u32 = bit_6 as _;
+                let bit_6: u32 = unsafe { ::std::mem::transmute(bit_6) };
                 bit_6 as u64
             });
         __bindgen_bitfield_unit
@@ -1846,7 +2339,7 @@ impl capabilities {
                 6usize,
                 1u8,
             >({
-                let bit_7: u32 = bit_7 as _;
+                let bit_7: u32 = unsafe { ::std::mem::transmute(bit_7) };
                 bit_7 as u64
             });
         __bindgen_bitfield_unit
@@ -1854,7 +2347,7 @@ impl capabilities {
                 7usize,
                 1u8,
             >({
-                let bit_8: u32 = bit_8 as _;
+                let bit_8: u32 = unsafe { ::std::mem::transmute(bit_8) };
                 bit_8 as u64
             });
         __bindgen_bitfield_unit
@@ -1862,7 +2355,7 @@ impl capabilities {
                 8usize,
                 1u8,
             >({
-                let bit_9: u32 = bit_9 as _;
+                let bit_9: u32 = unsafe { ::std::mem::transmute(bit_9) };
                 bit_9 as u64
             });
         __bindgen_bitfield_unit
@@ -1870,7 +2363,7 @@ impl capabilities {
                 9usize,
                 1u8,
             >({
-                let bit_10: u32 = bit_10 as _;
+                let bit_10: u32 = unsafe { ::std::mem::transmute(bit_10) };
                 bit_10 as u64
             });
         __bindgen_bitfield_unit
@@ -1878,7 +2371,7 @@ impl capabilities {
                 10usize,
                 1u8,
             >({
-                let bit_11: u32 = bit_11 as _;
+                let bit_11: u32 = unsafe { ::std::mem::transmute(bit_11) };
                 bit_11 as u64
             });
         __bindgen_bitfield_unit
@@ -1886,7 +2379,7 @@ impl capabilities {
                 11usize,
                 1u8,
             >({
-                let bit_12: u32 = bit_12 as _;
+                let bit_12: u32 = unsafe { ::std::mem::transmute(bit_12) };
                 bit_12 as u64
             });
         __bindgen_bitfield_unit
@@ -1894,7 +2387,7 @@ impl capabilities {
                 12usize,
                 1u8,
             >({
-                let bit_13: u32 = bit_13 as _;
+                let bit_13: u32 = unsafe { ::std::mem::transmute(bit_13) };
                 bit_13 as u64
             });
         __bindgen_bitfield_unit
@@ -1902,7 +2395,7 @@ impl capabilities {
                 13usize,
                 1u8,
             >({
-                let bit_14: u32 = bit_14 as _;
+                let bit_14: u32 = unsafe { ::std::mem::transmute(bit_14) };
                 bit_14 as u64
             });
         __bindgen_bitfield_unit
@@ -1910,7 +2403,7 @@ impl capabilities {
                 14usize,
                 1u8,
             >({
-                let bit_15: u32 = bit_15 as _;
+                let bit_15: u32 = unsafe { ::std::mem::transmute(bit_15) };
                 bit_15 as u64
             });
         __bindgen_bitfield_unit
@@ -1918,7 +2411,7 @@ impl capabilities {
                 15usize,
                 1u8,
             >({
-                let bit_16: u32 = bit_16 as _;
+                let bit_16: u32 = unsafe { ::std::mem::transmute(bit_16) };
                 bit_16 as u64
             });
         __bindgen_bitfield_unit
@@ -1926,7 +2419,7 @@ impl capabilities {
                 16usize,
                 1u8,
             >({
-                let bit_17: u32 = bit_17 as _;
+                let bit_17: u32 = unsafe { ::std::mem::transmute(bit_17) };
                 bit_17 as u64
             });
         __bindgen_bitfield_unit
@@ -1934,7 +2427,7 @@ impl capabilities {
                 17usize,
                 1u8,
             >({
-                let bit_18: u32 = bit_18 as _;
+                let bit_18: u32 = unsafe { ::std::mem::transmute(bit_18) };
                 bit_18 as u64
             });
         __bindgen_bitfield_unit
@@ -1942,7 +2435,7 @@ impl capabilities {
                 18usize,
                 1u8,
             >({
-                let bit_19: u32 = bit_19 as _;
+                let bit_19: u32 = unsafe { ::std::mem::transmute(bit_19) };
                 bit_19 as u64
             });
         __bindgen_bitfield_unit
@@ -1950,7 +2443,7 @@ impl capabilities {
                 19usize,
                 1u8,
             >({
-                let bit_20: u32 = bit_20 as _;
+                let bit_20: u32 = unsafe { ::std::mem::transmute(bit_20) };
                 bit_20 as u64
             });
         __bindgen_bitfield_unit
@@ -1958,7 +2451,7 @@ impl capabilities {
                 20usize,
                 1u8,
             >({
-                let bit_21: u32 = bit_21 as _;
+                let bit_21: u32 = unsafe { ::std::mem::transmute(bit_21) };
                 bit_21 as u64
             });
         __bindgen_bitfield_unit
@@ -1966,7 +2459,7 @@ impl capabilities {
                 21usize,
                 1u8,
             >({
-                let bit_22: u32 = bit_22 as _;
+                let bit_22: u32 = unsafe { ::std::mem::transmute(bit_22) };
                 bit_22 as u64
             });
         __bindgen_bitfield_unit
@@ -1974,7 +2467,7 @@ impl capabilities {
                 22usize,
                 1u8,
             >({
-                let bit_23: u32 = bit_23 as _;
+                let bit_23: u32 = unsafe { ::std::mem::transmute(bit_23) };
                 bit_23 as u64
             });
         __bindgen_bitfield_unit
@@ -1982,7 +2475,7 @@ impl capabilities {
                 23usize,
                 1u8,
             >({
-                let bit_24: u32 = bit_24 as _;
+                let bit_24: u32 = unsafe { ::std::mem::transmute(bit_24) };
                 bit_24 as u64
             });
         __bindgen_bitfield_unit
@@ -1990,7 +2483,7 @@ impl capabilities {
                 24usize,
                 1u8,
             >({
-                let bit_25: u32 = bit_25 as _;
+                let bit_25: u32 = unsafe { ::std::mem::transmute(bit_25) };
                 bit_25 as u64
             });
         __bindgen_bitfield_unit
@@ -1998,7 +2491,7 @@ impl capabilities {
                 25usize,
                 1u8,
             >({
-                let bit_26: u32 = bit_26 as _;
+                let bit_26: u32 = unsafe { ::std::mem::transmute(bit_26) };
                 bit_26 as u64
             });
         __bindgen_bitfield_unit
@@ -2006,7 +2499,7 @@ impl capabilities {
                 26usize,
                 1u8,
             >({
-                let bit_27: u32 = bit_27 as _;
+                let bit_27: u32 = unsafe { ::std::mem::transmute(bit_27) };
                 bit_27 as u64
             });
         __bindgen_bitfield_unit
@@ -2014,7 +2507,7 @@ impl capabilities {
                 27usize,
                 1u8,
             >({
-                let bit_28: u32 = bit_28 as _;
+                let bit_28: u32 = unsafe { ::std::mem::transmute(bit_28) };
                 bit_28 as u64
             });
         __bindgen_bitfield_unit
@@ -2022,7 +2515,7 @@ impl capabilities {
                 28usize,
                 1u8,
             >({
-                let bit_29: u32 = bit_29 as _;
+                let bit_29: u32 = unsafe { ::std::mem::transmute(bit_29) };
                 bit_29 as u64
             });
         __bindgen_bitfield_unit
@@ -2030,7 +2523,7 @@ impl capabilities {
                 29usize,
                 1u8,
             >({
-                let bit_30: u32 = bit_30 as _;
+                let bit_30: u32 = unsafe { ::std::mem::transmute(bit_30) };
                 bit_30 as u64
             });
         __bindgen_bitfield_unit
@@ -2038,7 +2531,7 @@ impl capabilities {
                 30usize,
                 1u8,
             >({
-                let bit_31: u32 = bit_31 as _;
+                let bit_31: u32 = unsafe { ::std::mem::transmute(bit_31) };
                 bit_31 as u64
             });
         __bindgen_bitfield_unit
@@ -2046,7 +2539,7 @@ impl capabilities {
                 31usize,
                 1u8,
             >({
-                let bit_32: u32 = bit_32 as _;
+                let bit_32: u32 = unsafe { ::std::mem::transmute(bit_32) };
                 bit_32 as u64
             });
         __bindgen_bitfield_unit
@@ -2054,7 +2547,7 @@ impl capabilities {
                 32usize,
                 1u8,
             >({
-                let bit_33: u32 = bit_33 as _;
+                let bit_33: u32 = unsafe { ::std::mem::transmute(bit_33) };
                 bit_33 as u64
             });
         __bindgen_bitfield_unit
@@ -2062,7 +2555,7 @@ impl capabilities {
                 33usize,
                 1u8,
             >({
-                let bit_34: u32 = bit_34 as _;
+                let bit_34: u32 = unsafe { ::std::mem::transmute(bit_34) };
                 bit_34 as u64
             });
         __bindgen_bitfield_unit
@@ -2070,7 +2563,7 @@ impl capabilities {
                 34usize,
                 1u8,
             >({
-                let bit_35: u32 = bit_35 as _;
+                let bit_35: u32 = unsafe { ::std::mem::transmute(bit_35) };
                 bit_35 as u64
             });
         __bindgen_bitfield_unit
@@ -2078,7 +2571,7 @@ impl capabilities {
                 35usize,
                 1u8,
             >({
-                let bit_36: u32 = bit_36 as _;
+                let bit_36: u32 = unsafe { ::std::mem::transmute(bit_36) };
                 bit_36 as u64
             });
         __bindgen_bitfield_unit
@@ -2086,7 +2579,7 @@ impl capabilities {
                 36usize,
                 1u8,
             >({
-                let bit_37: u32 = bit_37 as _;
+                let bit_37: u32 = unsafe { ::std::mem::transmute(bit_37) };
                 bit_37 as u64
             });
         __bindgen_bitfield_unit
@@ -2094,7 +2587,7 @@ impl capabilities {
                 37usize,
                 1u8,
             >({
-                let bit_38: u32 = bit_38 as _;
+                let bit_38: u32 = unsafe { ::std::mem::transmute(bit_38) };
                 bit_38 as u64
             });
         __bindgen_bitfield_unit
@@ -2102,7 +2595,7 @@ impl capabilities {
                 38usize,
                 1u8,
             >({
-                let bit_39: u32 = bit_39 as _;
+                let bit_39: u32 = unsafe { ::std::mem::transmute(bit_39) };
                 bit_39 as u64
             });
         __bindgen_bitfield_unit
@@ -2110,7 +2603,7 @@ impl capabilities {
                 39usize,
                 1u8,
             >({
-                let bit_40: u32 = bit_40 as _;
+                let bit_40: u32 = unsafe { ::std::mem::transmute(bit_40) };
                 bit_40 as u64
             });
         __bindgen_bitfield_unit
@@ -2118,7 +2611,7 @@ impl capabilities {
                 40usize,
                 1u8,
             >({
-                let bit_41: u32 = bit_41 as _;
+                let bit_41: u32 = unsafe { ::std::mem::transmute(bit_41) };
                 bit_41 as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -629,27 +629,39 @@ impl Default for jsval_layout__bindgen_ty_1 {
 }
 impl jsval_layout__bindgen_ty_1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn payload47(&self) -> u64 {
-        self._bitfield_1.get_const::<0usize, 47u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_payload47(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<0usize, 47u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn payload47_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<0usize, 47u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 47u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_payload47(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 47u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn payload47_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    0usize,
+                    47u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_payload47_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -659,17 +671,22 @@ impl jsval_layout__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn tag(&self) -> JSValueTag {
         unsafe {
             ::std::mem::transmute(self._bitfield_1.get_const::<47usize, 17u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_tag(&mut self, val: JSValueTag) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<47usize, 17u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<47usize, 17u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn tag_raw(this: *const Self) -> JSValueTag {
         unsafe {
             ::std::mem::transmute(
@@ -683,9 +700,10 @@ impl jsval_layout__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_tag_raw(this: *mut Self, val: JSValueTag) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -695,6 +713,7 @@ impl jsval_layout__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         payload47: u64,
         tag: JSValueTag,
@@ -705,7 +724,7 @@ impl jsval_layout__bindgen_ty_1 {
                 0usize,
                 47u8,
             >({
-                let payload47: u64 = payload47 as _;
+                let payload47: u64 = unsafe { ::std::mem::transmute(payload47) };
                 payload47 as u64
             });
         __bindgen_bitfield_unit
@@ -713,7 +732,7 @@ impl jsval_layout__bindgen_ty_1 {
                 47usize,
                 17u8,
             >({
-                let tag: u32 = tag as _;
+                let tag: u32 = unsafe { ::std::mem::transmute(tag) };
                 tag as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -598,27 +598,39 @@ const _: () = {
 };
 impl rte_eth_link {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn link_duplex(&self) -> u16 {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_link_duplex(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn link_duplex_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_link_duplex(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn link_duplex_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_link_duplex_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -628,27 +640,39 @@ impl rte_eth_link {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn link_autoneg(&self) -> u16 {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_link_autoneg(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn link_autoneg_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_link_autoneg(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn link_autoneg_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_link_autoneg_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -658,27 +682,39 @@ impl rte_eth_link {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn link_status(&self) -> u16 {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_link_status(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn link_status_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_link_status(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn link_status_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_link_status_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -688,6 +724,7 @@ impl rte_eth_link {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         link_duplex: u16,
         link_autoneg: u16,
@@ -699,7 +736,7 @@ impl rte_eth_link {
                 0usize,
                 1u8,
             >({
-                let link_duplex: u16 = link_duplex as _;
+                let link_duplex: u16 = unsafe { ::std::mem::transmute(link_duplex) };
                 link_duplex as u64
             });
         __bindgen_bitfield_unit
@@ -707,7 +744,7 @@ impl rte_eth_link {
                 1usize,
                 1u8,
             >({
-                let link_autoneg: u16 = link_autoneg as _;
+                let link_autoneg: u16 = unsafe { ::std::mem::transmute(link_autoneg) };
                 link_autoneg as u64
             });
         __bindgen_bitfield_unit
@@ -715,7 +752,7 @@ impl rte_eth_link {
                 2usize,
                 1u8,
             >({
-                let link_status: u16 = link_status as _;
+                let link_status: u16 = unsafe { ::std::mem::transmute(link_status) };
                 link_status as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -597,27 +597,39 @@ impl Default for rte_eth_rxmode {
 }
 impl rte_eth_rxmode {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn header_split(&self) -> u16 {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_header_split(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn header_split_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_header_split(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn header_split_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_header_split_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -627,27 +639,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_ip_checksum(&self) -> u16 {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_hw_ip_checksum(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_ip_checksum_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_ip_checksum(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_ip_checksum_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_ip_checksum_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -657,27 +681,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_filter(&self) -> u16 {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_filter(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_filter_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_filter(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_filter_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_filter_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -687,27 +723,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_strip(&self) -> u16 {
-        self._bitfield_1.get_const::<3usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_strip(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_strip_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<3usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<3usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_strip(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<3usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_strip_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    3usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_strip_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -717,27 +765,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_extend(&self) -> u16 {
-        self._bitfield_1.get_const::<4usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_extend(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_extend_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<4usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_extend(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_extend_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    4usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_extend_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -747,27 +807,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn jumbo_frame(&self) -> u16 {
-        self._bitfield_1.get_const::<5usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_jumbo_frame(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn jumbo_frame_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<5usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_jumbo_frame(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<5usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn jumbo_frame_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    5usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_jumbo_frame_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -777,27 +849,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_strip_crc(&self) -> u16 {
-        self._bitfield_1.get_const::<6usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_hw_strip_crc(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_strip_crc_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_strip_crc(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<6usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_strip_crc_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    6usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_strip_crc_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -807,27 +891,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn enable_scatter(&self) -> u16 {
-        self._bitfield_1.get_const::<7usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_enable_scatter(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn enable_scatter_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_enable_scatter(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn enable_scatter_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    7usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_enable_scatter_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -837,27 +933,39 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn enable_lro(&self) -> u16 {
-        self._bitfield_1.get_const::<8usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_enable_lro(&mut self, val: u16) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn enable_lro_raw(this: *const Self) -> u16 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_enable_lro(&mut self, val: u16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn enable_lro_raw(this: *const Self) -> u16 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    8usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_enable_lro_raw(this: *mut Self, val: u16) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -867,6 +975,7 @@ impl rte_eth_rxmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         header_split: u16,
         hw_ip_checksum: u16,
@@ -884,7 +993,7 @@ impl rte_eth_rxmode {
                 0usize,
                 1u8,
             >({
-                let header_split: u16 = header_split as _;
+                let header_split: u16 = unsafe { ::std::mem::transmute(header_split) };
                 header_split as u64
             });
         __bindgen_bitfield_unit
@@ -892,7 +1001,9 @@ impl rte_eth_rxmode {
                 1usize,
                 1u8,
             >({
-                let hw_ip_checksum: u16 = hw_ip_checksum as _;
+                let hw_ip_checksum: u16 = unsafe {
+                    ::std::mem::transmute(hw_ip_checksum)
+                };
                 hw_ip_checksum as u64
             });
         __bindgen_bitfield_unit
@@ -900,7 +1011,9 @@ impl rte_eth_rxmode {
                 2usize,
                 1u8,
             >({
-                let hw_vlan_filter: u16 = hw_vlan_filter as _;
+                let hw_vlan_filter: u16 = unsafe {
+                    ::std::mem::transmute(hw_vlan_filter)
+                };
                 hw_vlan_filter as u64
             });
         __bindgen_bitfield_unit
@@ -908,7 +1021,7 @@ impl rte_eth_rxmode {
                 3usize,
                 1u8,
             >({
-                let hw_vlan_strip: u16 = hw_vlan_strip as _;
+                let hw_vlan_strip: u16 = unsafe { ::std::mem::transmute(hw_vlan_strip) };
                 hw_vlan_strip as u64
             });
         __bindgen_bitfield_unit
@@ -916,7 +1029,9 @@ impl rte_eth_rxmode {
                 4usize,
                 1u8,
             >({
-                let hw_vlan_extend: u16 = hw_vlan_extend as _;
+                let hw_vlan_extend: u16 = unsafe {
+                    ::std::mem::transmute(hw_vlan_extend)
+                };
                 hw_vlan_extend as u64
             });
         __bindgen_bitfield_unit
@@ -924,7 +1039,7 @@ impl rte_eth_rxmode {
                 5usize,
                 1u8,
             >({
-                let jumbo_frame: u16 = jumbo_frame as _;
+                let jumbo_frame: u16 = unsafe { ::std::mem::transmute(jumbo_frame) };
                 jumbo_frame as u64
             });
         __bindgen_bitfield_unit
@@ -932,7 +1047,7 @@ impl rte_eth_rxmode {
                 6usize,
                 1u8,
             >({
-                let hw_strip_crc: u16 = hw_strip_crc as _;
+                let hw_strip_crc: u16 = unsafe { ::std::mem::transmute(hw_strip_crc) };
                 hw_strip_crc as u64
             });
         __bindgen_bitfield_unit
@@ -940,7 +1055,9 @@ impl rte_eth_rxmode {
                 7usize,
                 1u8,
             >({
-                let enable_scatter: u16 = enable_scatter as _;
+                let enable_scatter: u16 = unsafe {
+                    ::std::mem::transmute(enable_scatter)
+                };
                 enable_scatter as u64
             });
         __bindgen_bitfield_unit
@@ -948,7 +1065,7 @@ impl rte_eth_rxmode {
                 8usize,
                 1u8,
             >({
-                let enable_lro: u16 = enable_lro as _;
+                let enable_lro: u16 = unsafe { ::std::mem::transmute(enable_lro) };
                 enable_lro as u64
             });
         __bindgen_bitfield_unit
@@ -1000,27 +1117,39 @@ impl Default for rte_eth_txmode {
 }
 impl rte_eth_txmode {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_reject_tagged(&self) -> u8 {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_reject_tagged(&mut self, val: u8) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_reject_tagged_raw(this: *const Self) -> u8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_reject_tagged(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_reject_tagged_raw(this: *const Self) -> u8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_reject_tagged_raw(this: *mut Self, val: u8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -1030,27 +1159,39 @@ impl rte_eth_txmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_reject_untagged(&self) -> u8 {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_reject_untagged(&mut self, val: u8) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_reject_untagged_raw(this: *const Self) -> u8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_reject_untagged(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_reject_untagged_raw(this: *const Self) -> u8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_reject_untagged_raw(this: *mut Self, val: u8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -1060,27 +1201,39 @@ impl rte_eth_txmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn hw_vlan_insert_pvid(&self) -> u8 {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_hw_vlan_insert_pvid(&mut self, val: u8) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn hw_vlan_insert_pvid_raw(this: *const Self) -> u8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_hw_vlan_insert_pvid(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn hw_vlan_insert_pvid_raw(this: *const Self) -> u8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_hw_vlan_insert_pvid_raw(this: *mut Self, val: u8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -1090,6 +1243,7 @@ impl rte_eth_txmode {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         hw_vlan_reject_tagged: u8,
         hw_vlan_reject_untagged: u8,
@@ -1101,7 +1255,9 @@ impl rte_eth_txmode {
                 0usize,
                 1u8,
             >({
-                let hw_vlan_reject_tagged: u8 = hw_vlan_reject_tagged as _;
+                let hw_vlan_reject_tagged: u8 = unsafe {
+                    ::std::mem::transmute(hw_vlan_reject_tagged)
+                };
                 hw_vlan_reject_tagged as u64
             });
         __bindgen_bitfield_unit
@@ -1109,7 +1265,9 @@ impl rte_eth_txmode {
                 1usize,
                 1u8,
             >({
-                let hw_vlan_reject_untagged: u8 = hw_vlan_reject_untagged as _;
+                let hw_vlan_reject_untagged: u8 = unsafe {
+                    ::std::mem::transmute(hw_vlan_reject_untagged)
+                };
                 hw_vlan_reject_untagged as u64
             });
         __bindgen_bitfield_unit
@@ -1117,7 +1275,9 @@ impl rte_eth_txmode {
                 2usize,
                 1u8,
             >({
-                let hw_vlan_insert_pvid: u8 = hw_vlan_insert_pvid as _;
+                let hw_vlan_insert_pvid: u8 = unsafe {
+                    ::std::mem::transmute(hw_vlan_insert_pvid)
+                };
                 hw_vlan_insert_pvid as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -636,27 +636,39 @@ const _: () = {
 };
 impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l2_type(&self) -> u32 {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_l2_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l2_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l2_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l2_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l2_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -666,27 +678,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l3_type(&self) -> u32 {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_l3_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l3_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l3_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l3_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l3_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -696,27 +720,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l4_type(&self) -> u32 {
-        self._bitfield_1.get_const::<8usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_l4_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l4_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<8usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l4_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l4_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    8usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l4_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -726,27 +762,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn tun_type(&self) -> u32 {
-        self._bitfield_1.get_const::<12usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_tun_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<12usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn tun_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<12usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<12usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_tun_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<12usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn tun_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    12usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_tun_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -756,27 +804,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn inner_l2_type(&self) -> u32 {
-        self._bitfield_1.get_const::<16usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_inner_l2_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<16usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn inner_l2_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<16usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_inner_l2_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn inner_l2_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    16usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_inner_l2_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -786,27 +846,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn inner_l3_type(&self) -> u32 {
-        self._bitfield_1.get_const::<20usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_inner_l3_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<20usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn inner_l3_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<20usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<20usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_inner_l3_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<20usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn inner_l3_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    20usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_inner_l3_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -816,27 +888,39 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn inner_l4_type(&self) -> u32 {
-        self._bitfield_1.get_const::<24usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_inner_l4_type(&mut self, val: u32) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<24usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn inner_l4_type_raw(this: *const Self) -> u32 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<24usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_inner_l4_type(&mut self, val: u32) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn inner_l4_type_raw(this: *const Self) -> u32 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    24usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_inner_l4_type_raw(this: *mut Self, val: u32) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -846,6 +930,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         l2_type: u32,
         l3_type: u32,
@@ -861,7 +946,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 0usize,
                 4u8,
             >({
-                let l2_type: u32 = l2_type as _;
+                let l2_type: u32 = unsafe { ::std::mem::transmute(l2_type) };
                 l2_type as u64
             });
         __bindgen_bitfield_unit
@@ -869,7 +954,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 4usize,
                 4u8,
             >({
-                let l3_type: u32 = l3_type as _;
+                let l3_type: u32 = unsafe { ::std::mem::transmute(l3_type) };
                 l3_type as u64
             });
         __bindgen_bitfield_unit
@@ -877,7 +962,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 8usize,
                 4u8,
             >({
-                let l4_type: u32 = l4_type as _;
+                let l4_type: u32 = unsafe { ::std::mem::transmute(l4_type) };
                 l4_type as u64
             });
         __bindgen_bitfield_unit
@@ -885,7 +970,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 12usize,
                 4u8,
             >({
-                let tun_type: u32 = tun_type as _;
+                let tun_type: u32 = unsafe { ::std::mem::transmute(tun_type) };
                 tun_type as u64
             });
         __bindgen_bitfield_unit
@@ -893,7 +978,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 16usize,
                 4u8,
             >({
-                let inner_l2_type: u32 = inner_l2_type as _;
+                let inner_l2_type: u32 = unsafe { ::std::mem::transmute(inner_l2_type) };
                 inner_l2_type as u64
             });
         __bindgen_bitfield_unit
@@ -901,7 +986,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 20usize,
                 4u8,
             >({
-                let inner_l3_type: u32 = inner_l3_type as _;
+                let inner_l3_type: u32 = unsafe { ::std::mem::transmute(inner_l3_type) };
                 inner_l3_type as u64
             });
         __bindgen_bitfield_unit
@@ -909,7 +994,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
                 24usize,
                 4u8,
             >({
-                let inner_l4_type: u32 = inner_l4_type as _;
+                let inner_l4_type: u32 = unsafe { ::std::mem::transmute(inner_l4_type) };
                 inner_l4_type as u64
             });
         __bindgen_bitfield_unit
@@ -1142,27 +1227,39 @@ const _: () = {
 };
 impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l2_len(&self) -> u64 {
-        self._bitfield_1.get_const::<0usize, 7u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_l2_len(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l2_len_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<0usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 7u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l2_len(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l2_len_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    0usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l2_len_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1172,27 +1269,39 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l3_len(&self) -> u64 {
-        self._bitfield_1.get_const::<7usize, 9u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_l3_len(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<7usize, 9u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l3_len_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<7usize, 9u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 9u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l3_len(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 9u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l3_len_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    7usize,
+                    9u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l3_len_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1202,27 +1311,39 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn l4_len(&self) -> u64 {
-        self._bitfield_1.get_const::<16usize, 8u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_l4_len(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn l4_len_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<16usize, 8u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 8u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_l4_len(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 8u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn l4_len_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    16usize,
+                    8u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_l4_len_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1232,27 +1353,39 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn tso_segsz(&self) -> u64 {
-        self._bitfield_1.get_const::<24usize, 16u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_tso_segsz(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<24usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn tso_segsz_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<24usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<24usize, 16u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_tso_segsz(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<24usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn tso_segsz_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    24usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_tso_segsz_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1262,27 +1395,39 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn outer_l3_len(&self) -> u64 {
-        self._bitfield_1.get_const::<40usize, 9u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_outer_l3_len(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<40usize, 9u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn outer_l3_len_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<40usize, 9u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<40usize, 9u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_outer_l3_len(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<40usize, 9u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn outer_l3_len_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    40usize,
+                    9u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_outer_l3_len_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1292,27 +1437,39 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn outer_l2_len(&self) -> u64 {
-        self._bitfield_1.get_const::<49usize, 7u8>() as u64 as _
-    }
-    #[inline]
-    pub fn set_outer_l2_len(&mut self, val: u64) {
-        let val: u64 = val as _;
-        self._bitfield_1.set_const::<49usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn outer_l2_len_raw(this: *const Self) -> u64 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 7usize],
-            >>::raw_get_const::<49usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u64 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<49usize, 7u8>() as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_outer_l2_len(&mut self, val: u64) {
+        unsafe {
+            let val: u64 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<49usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn outer_l2_len_raw(this: *const Self) -> u64 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 7usize],
+                >>::raw_get_const::<
+                    49usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u64,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_outer_l2_len_raw(this: *mut Self, val: u64) {
         unsafe {
-            let val: u64 = val as _;
+            let val: u64 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 7usize],
             >>::raw_set_const::<
@@ -1322,6 +1479,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         l2_len: u64,
         l3_len: u64,
@@ -1336,7 +1494,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 0usize,
                 7u8,
             >({
-                let l2_len: u64 = l2_len as _;
+                let l2_len: u64 = unsafe { ::std::mem::transmute(l2_len) };
                 l2_len as u64
             });
         __bindgen_bitfield_unit
@@ -1344,7 +1502,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 7usize,
                 9u8,
             >({
-                let l3_len: u64 = l3_len as _;
+                let l3_len: u64 = unsafe { ::std::mem::transmute(l3_len) };
                 l3_len as u64
             });
         __bindgen_bitfield_unit
@@ -1352,7 +1510,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 16usize,
                 8u8,
             >({
-                let l4_len: u64 = l4_len as _;
+                let l4_len: u64 = unsafe { ::std::mem::transmute(l4_len) };
                 l4_len as u64
             });
         __bindgen_bitfield_unit
@@ -1360,7 +1518,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 24usize,
                 16u8,
             >({
-                let tso_segsz: u64 = tso_segsz as _;
+                let tso_segsz: u64 = unsafe { ::std::mem::transmute(tso_segsz) };
                 tso_segsz as u64
             });
         __bindgen_bitfield_unit
@@ -1368,7 +1526,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 40usize,
                 9u8,
             >({
-                let outer_l3_len: u64 = outer_l3_len as _;
+                let outer_l3_len: u64 = unsafe { ::std::mem::transmute(outer_l3_len) };
                 outer_l3_len as u64
             });
         __bindgen_bitfield_unit
@@ -1376,7 +1534,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
                 49usize,
                 7u8,
             >({
-                let outer_l2_len: u64 = outer_l2_len as _;
+                let outer_l2_len: u64 = unsafe { ::std::mem::transmute(outer_l2_len) };
                 outer_l2_len as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -518,27 +518,39 @@ const _: () = {
 };
 impl C {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> bool {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -548,27 +560,39 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> bool {
-        self._bitfield_1.get_const::<1usize, 7u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 7u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -578,6 +602,7 @@ impl C {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(a: bool, b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -585,7 +610,7 @@ impl C {
                 0usize,
                 1u8,
             >({
-                let a: u8 = a as _;
+                let a: u8 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -593,7 +618,7 @@ impl C {
                 1usize,
                 7u8,
             >({
-                let b: u8 = b as _;
+                let b: u8 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -518,27 +518,39 @@ const _: () = {
 };
 impl Date {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn day(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<0usize, 5u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_day(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 5u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn day_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<0usize, 5u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 5u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_day(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 5u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn day_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    0usize,
+                    5u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_day_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -548,27 +560,39 @@ impl Date {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn month(&self) -> ::std::os::raw::c_uchar {
-        self._bitfield_1.get_const::<5usize, 4u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_month(&mut self, val: ::std::os::raw::c_uchar) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<5usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn month_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<5usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<5usize, 4u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_month(&mut self, val: ::std::os::raw::c_uchar) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<5usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn month_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    5usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_month_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -578,27 +602,39 @@ impl Date {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn year(&self) -> ::std::os::raw::c_short {
-        self._bitfield_1.get_const::<9usize, 15u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_year(&mut self, val: ::std::os::raw::c_short) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<9usize, 15u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn year_raw(this: *const Self) -> ::std::os::raw::c_short {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 3usize],
-            >>::raw_get_const::<9usize, 15u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<9usize, 15u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_year(&mut self, val: ::std::os::raw::c_short) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<9usize, 15u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn year_raw(this: *const Self) -> ::std::os::raw::c_short {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get_const::<
+                    9usize,
+                    15u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_year_raw(this: *mut Self, val: ::std::os::raw::c_short) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 3usize],
             >>::raw_set_const::<
@@ -608,6 +644,7 @@ impl Date {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         day: ::std::os::raw::c_uchar,
         month: ::std::os::raw::c_uchar,
@@ -619,7 +656,7 @@ impl Date {
                 0usize,
                 5u8,
             >({
-                let day: u8 = day as _;
+                let day: u8 = unsafe { ::std::mem::transmute(day) };
                 day as u64
             });
         __bindgen_bitfield_unit
@@ -627,7 +664,7 @@ impl Date {
                 5usize,
                 4u8,
             >({
-                let month: u8 = month as _;
+                let month: u8 = unsafe { ::std::mem::transmute(month) };
                 month as u64
             });
         __bindgen_bitfield_unit
@@ -635,7 +672,7 @@ impl Date {
                 9usize,
                 15u8,
             >({
-                let year: u16 = year as _;
+                let year: u16 = unsafe { ::std::mem::transmute(year) };
                 year as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -535,27 +535,39 @@ const _: () = {
 };
 impl PrivateBitFields {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn a(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -565,27 +577,39 @@ impl PrivateBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn b(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    fn set_b(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -595,6 +619,7 @@ impl PrivateBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         a: ::std::os::raw::c_uint,
         b: ::std::os::raw::c_uint,
@@ -605,7 +630,7 @@ impl PrivateBitFields {
                 0usize,
                 4u8,
             >({
-                let a: u32 = a as _;
+                let a: u32 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -613,7 +638,7 @@ impl PrivateBitFields {
                 4usize,
                 4u8,
             >({
-                let b: u32 = b as _;
+                let b: u32 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit
@@ -633,27 +658,39 @@ const _: () = {
 };
 impl PublicBitFields {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -663,27 +700,39 @@ impl PublicBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -693,6 +742,7 @@ impl PublicBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_uint,
         b: ::std::os::raw::c_uint,
@@ -703,7 +753,7 @@ impl PublicBitFields {
                 0usize,
                 4u8,
             >({
-                let a: u32 = a as _;
+                let a: u32 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -711,7 +761,7 @@ impl PublicBitFields {
                 4usize,
                 4u8,
             >({
-                let b: u32 = b as _;
+                let b: u32 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit
@@ -731,27 +781,39 @@ const _: () = {
 };
 impl MixedBitFields {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn a(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    fn set_a(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -761,27 +823,39 @@ impl MixedBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn d(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_d(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_d(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_d_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -791,6 +865,7 @@ impl MixedBitFields {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         a: ::std::os::raw::c_uint,
         d: ::std::os::raw::c_uint,
@@ -801,7 +876,7 @@ impl MixedBitFields {
                 0usize,
                 4u8,
             >({
-                let a: u32 = a as _;
+                let a: u32 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -809,7 +884,7 @@ impl MixedBitFields {
                 4usize,
                 4u8,
             >({
-                let d: u32 = d as _;
+                let d: u32 = unsafe { ::std::mem::transmute(d) };
                 d as u64
             });
         __bindgen_bitfield_unit
@@ -959,27 +1034,39 @@ const _: () = {
 };
 impl Override {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bf_a(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bf_a(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bf_a_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<0usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bf_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bf_a_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    0usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bf_a_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -989,27 +1076,39 @@ impl Override {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn bf_b(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<4usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    fn set_bf_b(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn bf_b_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<4usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<4usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_bf_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<4usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn bf_b_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    4usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_bf_b_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -1019,27 +1118,39 @@ impl Override {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn private_bf_c(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<8usize, 4u8>() as u32 as _
-    }
-    #[inline]
-    fn set_private_bf_c(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
-    }
-    #[inline]
-    unsafe fn private_bf_c_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<8usize, 4u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<8usize, 4u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    fn set_private_bf_c(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<8usize, 4u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    unsafe fn private_bf_c_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    8usize,
+                    4u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     unsafe fn set_private_bf_c_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -1049,6 +1160,7 @@ impl Override {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     fn new_bitfield_1(
         bf_a: ::std::os::raw::c_uint,
         bf_b: ::std::os::raw::c_uint,
@@ -1060,7 +1172,7 @@ impl Override {
                 0usize,
                 4u8,
             >({
-                let bf_a: u32 = bf_a as _;
+                let bf_a: u32 = unsafe { ::std::mem::transmute(bf_a) };
                 bf_a as u64
             });
         __bindgen_bitfield_unit
@@ -1068,7 +1180,7 @@ impl Override {
                 4usize,
                 4u8,
             >({
-                let bf_b: u32 = bf_b as _;
+                let bf_b: u32 = unsafe { ::std::mem::transmute(bf_b) };
                 bf_b as u64
             });
         __bindgen_bitfield_unit
@@ -1076,7 +1188,7 @@ impl Override {
                 8usize,
                 4u8,
             >({
-                let private_bf_c: u32 = private_bf_c as _;
+                let private_bf_c: u32 = unsafe { ::std::mem::transmute(private_bf_c) };
                 private_bf_c as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
+++ b/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
@@ -551,27 +551,39 @@ const _: () = {
 };
 impl redundant_packed_bitfield {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b0(&self) -> u8 {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_b0(&mut self, val: u8) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b0_raw(this: *const Self) -> u8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b0(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b0_raw(this: *const Self) -> u8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b0_raw(this: *mut Self, val: u8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -581,27 +593,39 @@ impl redundant_packed_bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b1(&self) -> u8 {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u8 as _
-    }
-    #[inline]
-    pub fn set_b1(&mut self, val: u8) {
-        let val: u8 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b1_raw(this: *const Self) -> u8 {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b1(&mut self, val: u8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b1_raw(this: *const Self) -> u8 {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b1_raw(this: *mut Self, val: u8) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -611,6 +635,7 @@ impl redundant_packed_bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(b0: u8, b1: u8) -> __BindgenBitfieldUnit<[u8; 1usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
@@ -618,7 +643,7 @@ impl redundant_packed_bitfield {
                 0usize,
                 1u8,
             >({
-                let b0: u8 = b0 as _;
+                let b0: u8 = unsafe { ::std::mem::transmute(b0) };
                 b0 as u64
             });
         __bindgen_bitfield_unit
@@ -626,7 +651,7 @@ impl redundant_packed_bitfield {
                 1usize,
                 1u8,
             >({
-                let b1: u8 = b1 as _;
+                let b1: u8 = unsafe { ::std::mem::transmute(b1) };
                 b1 as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -521,27 +521,39 @@ const _: () = {
 };
 impl bitfield {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<0usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -551,27 +563,39 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<1usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<1usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<1usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<1usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    1usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -581,27 +605,39 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn c(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<2usize, 1u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<2usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<2usize, 1u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<2usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    2usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -611,27 +647,39 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn d(&self) -> ::std::os::raw::c_ushort {
-        self._bitfield_1.get_const::<6usize, 2u8>() as u16 as _
-    }
-    #[inline]
-    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
-        let val: u16 = val as _;
-        self._bitfield_1.set_const::<6usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<6usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u16 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<6usize, 2u8>() as u16)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<6usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    6usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u16,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_d_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u16 = val as _;
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -641,6 +689,7 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_ushort,
         b: ::std::os::raw::c_ushort,
@@ -653,7 +702,7 @@ impl bitfield {
                 0usize,
                 1u8,
             >({
-                let a: u16 = a as _;
+                let a: u16 = unsafe { ::std::mem::transmute(a) };
                 a as u64
             });
         __bindgen_bitfield_unit
@@ -661,7 +710,7 @@ impl bitfield {
                 1usize,
                 1u8,
             >({
-                let b: u16 = b as _;
+                let b: u16 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit
@@ -669,7 +718,7 @@ impl bitfield {
                 2usize,
                 1u8,
             >({
-                let c: u16 = c as _;
+                let c: u16 = unsafe { ::std::mem::transmute(c) };
                 c as u64
             });
         __bindgen_bitfield_unit
@@ -677,33 +726,45 @@ impl bitfield {
                 6usize,
                 2u8,
             >({
-                let d: u16 = d as _;
+                let d: u16 = unsafe { ::std::mem::transmute(d) };
                 d as u64
             });
         __bindgen_bitfield_unit
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn f(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_2.get_const::<0usize, 2u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_f(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_2.set_const::<0usize, 2u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn f_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<0usize, 2u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 2u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_f(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<0usize, 2u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn f_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    0usize,
+                    2u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_f_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -713,27 +774,39 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn g(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_2.get_const::<32usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_g(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_2.set_const::<32usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 8usize],
-            >>::raw_get_const::<32usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_2.get_const::<32usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_g(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<32usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 8usize],
+                >>::raw_get_const::<
+                    32usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_g_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 8usize],
             >>::raw_set_const::<
@@ -743,6 +816,7 @@ impl bitfield {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_2(
         f: ::std::os::raw::c_uint,
         g: ::std::os::raw::c_uint,
@@ -753,7 +827,7 @@ impl bitfield {
                 0usize,
                 2u8,
             >({
-                let f: u32 = f as _;
+                let f: u32 = unsafe { ::std::mem::transmute(f) };
                 f as u64
             });
         __bindgen_bitfield_unit
@@ -761,7 +835,7 @@ impl bitfield {
                 32usize,
                 32u8,
             >({
-                let g: u32 = g as _;
+                let g: u32 = unsafe { ::std::mem::transmute(g) };
                 g as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -552,27 +552,39 @@ impl Default for timex_named {
 }
 impl timex_named {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn a(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<0usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    0usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -582,27 +594,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<32usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<32usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<32usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<32usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<32usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    32usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -612,27 +636,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<64usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<64usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<64usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<64usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<64usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    64usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -642,27 +678,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn d(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<96usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_d(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<96usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<96usize, 32u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<96usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_d(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<96usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    96usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_d_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -672,29 +720,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn e(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<128usize, 32u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<128usize, 32u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_e(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<128usize, 32u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<128usize, 32u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                128usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    128usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_e_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -704,29 +762,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn f(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<160usize, 32u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<160usize, 32u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_f(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<160usize, 32u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<160usize, 32u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn f_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                160usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    160usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_f_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -736,29 +804,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn g(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<192usize, 32u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<192usize, 32u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_g(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<192usize, 32u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<192usize, 32u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn g_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                192usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    192usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_g_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -768,29 +846,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn h(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<224usize, 32u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<224usize, 32u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_h(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<224usize, 32u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<224usize, 32u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn h_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                224usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    224usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_h_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -800,29 +888,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn i(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<256usize, 32u8>() as u32 as _
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<256usize, 32u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_i(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<256usize, 32u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<256usize, 32u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn i_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                256usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    256usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_i_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -832,29 +930,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn j(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<288usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_j(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<288usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn j_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                288usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<288usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_j(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<288usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn j_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    288usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_j_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<
@@ -864,29 +972,39 @@ impl timex_named {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn k(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<320usize, 32u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_k(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<320usize, 32u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn k_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 44usize],
-            >>::raw_get_const::<
-                320usize,
-                32u8,
-            >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<320usize, 32u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_k(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<320usize, 32u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn k_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 44usize],
+                >>::raw_get_const::<
+                    320usize,
+                    32u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_k_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 44usize],
             >>::raw_set_const::<

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -528,29 +528,39 @@ impl Default for U4 {
 }
 impl U4 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn derp(&self) -> ::std::os::raw::c_uint {
-        unsafe { self._bitfield_1.get_const::<0usize, 1u8>() as u32 as _ }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_derp(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn derp_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_derp_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -560,6 +570,7 @@ impl U4 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         derp: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
@@ -569,7 +580,7 @@ impl U4 {
                 0usize,
                 1u8,
             >({
-                let derp: u32 = derp as _;
+                let derp: u32 = unsafe { ::std::mem::transmute(derp) };
                 derp as u64
             });
         __bindgen_bitfield_unit
@@ -597,29 +608,39 @@ impl Default for B {
 }
 impl B {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn foo(&self) -> ::std::os::raw::c_uint {
-        unsafe { self._bitfield_1.get_const::<0usize, 31u8>() as u32 as _ }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 31u8>() as u32)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_foo(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             self._bitfield_1.set_const::<0usize, 31u8>(val as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn foo_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 31u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    31u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_foo_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -629,29 +650,39 @@ impl B {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bar(&self) -> ::std::os::raw::c_uchar {
-        unsafe { self._bitfield_1.get_const::<0usize, 1u8>() as u8 as _ }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 1u8>() as u8)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             self._bitfield_1.set_const::<0usize, 1u8>(val as u64)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn bar_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_get_const::<0usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u8 as _
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get_const::<
+                    0usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u8,
+            )
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bar_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 1usize],
             >>::raw_set_const::<
@@ -661,6 +692,7 @@ impl B {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
@@ -671,7 +703,7 @@ impl B {
                 0usize,
                 31u8,
             >({
-                let foo: u32 = foo as _;
+                let foo: u32 = unsafe { ::std::mem::transmute(foo) };
                 foo as u64
             });
         __bindgen_bitfield_unit
@@ -679,7 +711,7 @@ impl B {
                 0usize,
                 1u8,
             >({
-                let bar: u8 = bar as _;
+                let bar: u8 = unsafe { ::std::mem::transmute(bar) };
                 bar as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -527,27 +527,39 @@ const _: () = {
 };
 impl foo__bindgen_ty_1 {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn b(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<0usize, 7u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 7u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 7u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 7u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    7u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -557,27 +569,39 @@ impl foo__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn c(&self) -> ::std::os::raw::c_int {
-        self._bitfield_1.get_const::<7usize, 25u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<7usize, 25u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<7usize, 25u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<7usize, 25u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<7usize, 25u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_int {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    7usize,
+                    25u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_int) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -587,6 +611,7 @@ impl foo__bindgen_ty_1 {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         b: ::std::os::raw::c_int,
         c: ::std::os::raw::c_int,
@@ -597,7 +622,7 @@ impl foo__bindgen_ty_1 {
                 0usize,
                 7u8,
             >({
-                let b: u32 = b as _;
+                let b: u32 = unsafe { ::std::mem::transmute(b) };
                 b as u64
             });
         __bindgen_bitfield_unit
@@ -605,7 +630,7 @@ impl foo__bindgen_ty_1 {
                 7usize,
                 25u8,
             >({
-                let c: u32 = c as _;
+                let c: u32 = unsafe { ::std::mem::transmute(c) };
                 c as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -584,27 +584,39 @@ impl Default for Weird {
 }
 impl Weird {
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bitTest(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<0usize, 16u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bitTest(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bitTest_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<0usize, 16u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<0usize, 16u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bitTest(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<0usize, 16u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bitTest_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    0usize,
+                    16u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bitTest_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -614,27 +626,39 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn bitTest2(&self) -> ::std::os::raw::c_uint {
-        self._bitfield_1.get_const::<16usize, 15u8>() as u32 as _
-    }
-    #[inline]
-    pub fn set_bitTest2(&mut self, val: ::std::os::raw::c_uint) {
-        let val: u32 = val as _;
-        self._bitfield_1.set_const::<16usize, 15u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn bitTest2_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_get_const::<16usize, 15u8>(::std::ptr::addr_of!((*this)._bitfield_1))
-                as u32 as _
+            ::std::mem::transmute(self._bitfield_1.get_const::<16usize, 15u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_bitTest2(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set_const::<16usize, 15u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn bitTest2_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 4usize],
+                >>::raw_get_const::<
+                    16usize,
+                    15u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_1)) as u32,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_bitTest2_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 4usize],
             >>::raw_set_const::<
@@ -644,6 +668,7 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_1(
         bitTest: ::std::os::raw::c_uint,
         bitTest2: ::std::os::raw::c_uint,
@@ -654,7 +679,7 @@ impl Weird {
                 0usize,
                 16u8,
             >({
-                let bitTest: u32 = bitTest as _;
+                let bitTest: u32 = unsafe { ::std::mem::transmute(bitTest) };
                 bitTest as u64
             });
         __bindgen_bitfield_unit
@@ -662,23 +687,28 @@ impl Weird {
                 16usize,
                 15u8,
             >({
-                let bitTest2: u32 = bitTest2 as _;
+                let bitTest2: u32 = unsafe { ::std::mem::transmute(bitTest2) };
                 bitTest2 as u64
             });
         __bindgen_bitfield_unit
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn mFillOpacitySource(&self) -> nsStyleSVGOpacitySource {
         unsafe {
             ::std::mem::transmute(self._bitfield_2.get_const::<0usize, 3u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_mFillOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
-        let val: u32 = val as _;
-        self._bitfield_2.set_const::<0usize, 3u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<0usize, 3u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn mFillOpacitySource_raw(this: *const Self) -> nsStyleSVGOpacitySource {
         unsafe {
             ::std::mem::transmute(
@@ -692,12 +722,13 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_mFillOpacitySource_raw(
         this: *mut Self,
         val: nsStyleSVGOpacitySource,
     ) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -707,17 +738,22 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn mStrokeOpacitySource(&self) -> nsStyleSVGOpacitySource {
         unsafe {
             ::std::mem::transmute(self._bitfield_2.get_const::<3usize, 3u8>() as u32)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn set_mStrokeOpacitySource(&mut self, val: nsStyleSVGOpacitySource) {
-        let val: u32 = val as _;
-        self._bitfield_2.set_const::<3usize, 3u8>(val as u64)
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<3usize, 3u8>(val as u64)
+        }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn mStrokeOpacitySource_raw(
         this: *const Self,
     ) -> nsStyleSVGOpacitySource {
@@ -733,12 +769,13 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_mStrokeOpacitySource_raw(
         this: *mut Self,
         val: nsStyleSVGOpacitySource,
     ) {
         unsafe {
-            let val: u32 = val as _;
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -748,27 +785,39 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn mStrokeDasharrayFromObject(&self) -> bool {
-        self._bitfield_2.get_const::<6usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_mStrokeDasharrayFromObject(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<6usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn mStrokeDasharrayFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<6usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_2.get_const::<6usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_mStrokeDasharrayFromObject(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<6usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn mStrokeDasharrayFromObject_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    6usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_mStrokeDasharrayFromObject_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -778,27 +827,39 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn mStrokeDashoffsetFromObject(&self) -> bool {
-        self._bitfield_2.get_const::<7usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_mStrokeDashoffsetFromObject(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<7usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn mStrokeDashoffsetFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<7usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_2.get_const::<7usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_mStrokeDashoffsetFromObject(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<7usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn mStrokeDashoffsetFromObject_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    7usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_mStrokeDashoffsetFromObject_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -808,27 +869,39 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn mStrokeWidthFromObject(&self) -> bool {
-        self._bitfield_2.get_const::<8usize, 1u8>() as u8 != 0
-    }
-    #[inline]
-    pub fn set_mStrokeWidthFromObject(&mut self, val: bool) {
-        let val: u8 = val as _;
-        self._bitfield_2.set_const::<8usize, 1u8>(val as u64)
-    }
-    #[inline]
-    pub unsafe fn mStrokeWidthFromObject_raw(this: *const Self) -> bool {
         unsafe {
-            <__BindgenBitfieldUnit<
-                [u8; 2usize],
-            >>::raw_get_const::<8usize, 1u8>(::std::ptr::addr_of!((*this)._bitfield_2))
-                as u8 != 0
+            ::std::mem::transmute(self._bitfield_2.get_const::<8usize, 1u8>() as u8)
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub fn set_mStrokeWidthFromObject(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set_const::<8usize, 1u8>(val as u64)
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
+    pub unsafe fn mStrokeWidthFromObject_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 2usize],
+                >>::raw_get_const::<
+                    8usize,
+                    1u8,
+                >(::std::ptr::addr_of!((*this)._bitfield_2)) as u8,
+            )
+        }
+    }
+    #[inline]
+    #[allow(unnecessary_transmutes)]
     pub unsafe fn set_mStrokeWidthFromObject_raw(this: *mut Self, val: bool) {
         unsafe {
-            let val: u8 = val as _;
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
                 [u8; 2usize],
             >>::raw_set_const::<
@@ -838,6 +911,7 @@ impl Weird {
         }
     }
     #[inline]
+    #[allow(unnecessary_transmutes)]
     pub fn new_bitfield_2(
         mFillOpacitySource: nsStyleSVGOpacitySource,
         mStrokeOpacitySource: nsStyleSVGOpacitySource,
@@ -851,7 +925,9 @@ impl Weird {
                 0usize,
                 3u8,
             >({
-                let mFillOpacitySource: u32 = mFillOpacitySource as _;
+                let mFillOpacitySource: u32 = unsafe {
+                    ::std::mem::transmute(mFillOpacitySource)
+                };
                 mFillOpacitySource as u64
             });
         __bindgen_bitfield_unit
@@ -859,7 +935,9 @@ impl Weird {
                 3usize,
                 3u8,
             >({
-                let mStrokeOpacitySource: u32 = mStrokeOpacitySource as _;
+                let mStrokeOpacitySource: u32 = unsafe {
+                    ::std::mem::transmute(mStrokeOpacitySource)
+                };
                 mStrokeOpacitySource as u64
             });
         __bindgen_bitfield_unit
@@ -867,7 +945,9 @@ impl Weird {
                 6usize,
                 1u8,
             >({
-                let mStrokeDasharrayFromObject: u8 = mStrokeDasharrayFromObject as _;
+                let mStrokeDasharrayFromObject: u8 = unsafe {
+                    ::std::mem::transmute(mStrokeDasharrayFromObject)
+                };
                 mStrokeDasharrayFromObject as u64
             });
         __bindgen_bitfield_unit
@@ -875,7 +955,9 @@ impl Weird {
                 7usize,
                 1u8,
             >({
-                let mStrokeDashoffsetFromObject: u8 = mStrokeDashoffsetFromObject as _;
+                let mStrokeDashoffsetFromObject: u8 = unsafe {
+                    ::std::mem::transmute(mStrokeDashoffsetFromObject)
+                };
                 mStrokeDashoffsetFromObject as u64
             });
         __bindgen_bitfield_unit
@@ -883,7 +965,9 @@ impl Weird {
                 8usize,
                 1u8,
             >({
-                let mStrokeWidthFromObject: u8 = mStrokeWidthFromObject as _;
+                let mStrokeWidthFromObject: u8 = unsafe {
+                    ::std::mem::transmute(mStrokeWidthFromObject)
+                };
                 mStrokeWidthFromObject as u64
             });
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/headers/issue-3454-enum-newtype-bitfield.h
+++ b/bindgen-tests/tests/headers/issue-3454-enum-newtype-bitfield.h
@@ -1,0 +1,14 @@
+// bindgen-flags: --default-enum-style newtype
+
+enum pipe_resource_usage {
+  PIPE_USAGE_DEFAULT,
+  PIPE_USAGE_IMMUTABLE,
+  PIPE_USAGE_DYNAMIC,
+  PIPE_USAGE_STREAM,
+  PIPE_USAGE_STAGING
+};
+
+struct pipe_resource {
+  unsigned compression_rate : 4;
+  enum pipe_resource_usage usage : 4;
+};

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1825,11 +1825,14 @@ impl Bitfield {
 
         let offset = self.offset_into_unit();
         let width = self.width() as u8;
+        let prefix = ctx.trait_prefix();
 
         ctor_impl.append_all(quote! {
             __bindgen_bitfield_unit.set_const::<#offset, #width>(
                 {
-                    let #param_name: #bitfield_int_ty = #param_name as _;
+                    let #param_name: #bitfield_int_ty = unsafe {
+                        ::#prefix::mem::transmute(#param_name)
+                    };
                     #param_name as u64
                 }
             );
@@ -2000,6 +2003,7 @@ impl FieldCodegen<'_> for BitfieldUnit {
         if generate_ctor {
             methods.extend(Some(quote! {
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec fn #ctor_name ( #( #ctor_params ),* ) -> #unit_field_ty {
                     let mut __bindgen_bitfield_unit: #unit_field_ty = Default::default();
                     #ctor_impl
@@ -2092,7 +2096,6 @@ impl<'a> FieldCodegen<'a> for Bitfield {
 
         let bitfield_ty_item = ctx.resolve_item(self.ty());
         let bitfield_ty = bitfield_ty_item.expect_type();
-        let bitfield_ty_kind = bitfield_ty.canonical_type(ctx).kind();
         let bitfield_ty_ident = bitfield_ty.name();
 
         let bitfield_ty_layout = bitfield_ty
@@ -2134,40 +2137,48 @@ impl<'a> FieldCodegen<'a> for Bitfield {
         if parent.is_union() && !struct_layout.is_rust_union() {
             methods.extend(Some(quote! {
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec fn #getter_name(&self) -> #bitfield_ty {
-                    self.#unit_field_ident.as_ref().get(#offset, #width)
-                        as #bitfield_int_ty
-                        as _
+                    unsafe {
+                        ::#prefix::mem::transmute(
+                            self.#unit_field_ident.as_ref().get(#offset, #width)
+                                as #bitfield_int_ty
+                        )
+                    }
                 }
 
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec fn #setter_name(&mut self, val: #bitfield_ty) {
-                    let val: #bitfield_int_ty = val as _;
-                    self.#unit_field_ident.as_mut().set(
-                        #offset,
-                        #width,
-                        val as u64
-                    )
+                    unsafe {
+                        let val: #bitfield_int_ty = ::#prefix::mem::transmute(val);
+                        self.#unit_field_ident.as_mut().set(
+                            #offset,
+                            #width,
+                            val as u64
+                        )
+                    }
                 }
             }));
 
             methods.extend(Some(quote! {
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec unsafe fn #raw_getter_name(this: *const Self) -> #bitfield_ty {
                     unsafe {
-                        <#unit_field_ty>::raw_get(
+                        ::#prefix::mem::transmute(<#unit_field_ty>::raw_get(
                             (*::#prefix::ptr::addr_of!((*this).#unit_field_ident)).as_ref() as *const _,
                             #offset,
                             #width,
-                        ) as #bitfield_int_ty
-                          as _
+                        ) as #bitfield_int_ty)
                     }
                 }
 
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec unsafe fn #raw_setter_name(this: *mut Self, val: #bitfield_ty) {
                     unsafe {
-                        let val: #bitfield_int_ty = val as _;
+                        let val: #bitfield_int_ty = ::#prefix::mem::transmute(val);
                         <#unit_field_ty>::raw_set(
                             (*::#prefix::ptr::addr_of_mut!((*this).#unit_field_ident)).as_mut() as *mut _,
                             #offset,
@@ -2178,67 +2189,46 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 }
             }));
         } else {
-            let is_rust_union =
-                parent.is_union() && struct_layout.is_rust_union();
-
-            let get = quote! { self.#unit_field_ident.get_const::<#offset, #width>() as #bitfield_int_ty };
-            let raw_get = quote! {
-                <#unit_field_ty>::raw_get_const::<#offset, #width>(
-                    ::#prefix::ptr::addr_of!((*this).#unit_field_ident),
-                ) as #bitfield_int_ty
-            };
-
-            let (getter_inner, raw_getter_inner) = match bitfield_ty_kind {
-                TypeKind::Int(IntKind::Bool) => {
-                    (quote! { #get != 0 }, quote! { #raw_get != 0 })
-                }
-                TypeKind::Enum(..) => (
-                    quote! { ::#prefix::mem::transmute(#get) },
-                    quote! { ::#prefix::mem::transmute(#raw_get) },
-                ),
-                _ => (quote! { #get as _ }, quote! { #raw_get as _ }),
-            };
-
-            let getter_body = if is_rust_union ||
-                matches!(bitfield_ty_kind, TypeKind::Enum(..))
-            {
-                quote! { unsafe { #getter_inner } }
-            } else {
-                getter_inner
-            };
-
-            let setter_inner = quote! {
-                let val: #bitfield_int_ty = val as _;
-                self.#unit_field_ident.set_const::<#offset, #width>(val as u64)
-            };
-            let setter_body = if is_rust_union {
-                quote! { unsafe { #setter_inner } }
-            } else {
-                setter_inner
-            };
-
             methods.extend(Some(quote! {
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec fn #getter_name(&self) -> #bitfield_ty {
-                    #getter_body
+                    unsafe {
+                        ::#prefix::mem::transmute(
+                            self.#unit_field_ident.get_const::<#offset, #width>()
+                                as #bitfield_int_ty
+                        )
+                    }
                 }
 
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec fn #setter_name(&mut self, val: #bitfield_ty) {
-                    #setter_body
+                    unsafe {
+                        let val: #bitfield_int_ty = ::#prefix::mem::transmute(val);
+                        self.#unit_field_ident.set_const::<#offset, #width>(
+                            val as u64
+                        )
+                    }
                 }
             }));
 
             methods.extend(Some(quote! {
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec unsafe fn #raw_getter_name(this: *const Self) -> #bitfield_ty {
-                    unsafe { #raw_getter_inner }
+                    unsafe {
+                        ::#prefix::mem::transmute(<#unit_field_ty>::raw_get_const::<#offset, #width>(
+                            ::#prefix::ptr::addr_of!((*this).#unit_field_ident),
+                        ) as #bitfield_int_ty)
+                    }
                 }
 
                 #[inline]
+                #[allow(unnecessary_transmutes)]
                 #access_spec unsafe fn #raw_setter_name(this: *mut Self, val: #bitfield_ty) {
                     unsafe {
-                        let val: #bitfield_int_ty = val as _;
+                        let val: #bitfield_int_ty = ::#prefix::mem::transmute(val);
                         <#unit_field_ty>::raw_set_const::<#offset, #width>(
                             ::#prefix::ptr::addr_of_mut!((*this).#unit_field_ident),
                             val as u64,


### PR DESCRIPTION
This reverts commits a502187aa552e8edcaba07c84fc3744cf36550a2 and 01d65d946ca11c77b1c2074404412499c16287f6, because it breaks when the bitfield is a newtype enum, and adds a test for that.

Fixes #3454.