### PR TITLE
Fix tests that fail when run concurrently.

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -356,12 +356,17 @@ macro_rules! test_header {
     ($function:ident, $header:expr) => {
         #[test]
         fn $function() {
+            let tmpdir = tempfile::tempdir().unwrap();
             let header = PathBuf::from($header);
-            let result = create_bindgen_builder(&header).and_then(|builder| {
-                let check_roundtrip =
-                    env::var_os("BINDGEN_DISABLE_ROUNDTRIP_TEST").is_none();
-                compare_generated_header(&header, builder, check_roundtrip)
-            });
+            let result =
+                create_bindgen_builder(&header).and_then(|mut builder| {
+                    builder.builder = builder
+                        .builder
+                        .clang_macro_fallback_build_dir(tmpdir.path());
+                    let check_roundtrip =
+                        env::var_os("BINDGEN_DISABLE_ROUNDTRIP_TEST").is_none();
+                    compare_generated_header(&header, builder, check_roundtrip)
+                });
 
             if let Err(err) = result {
                 panic!("{err}");


### PR DESCRIPTION
When building & testing bindgen on a multicore machine, I noticed persistent failures in `header_issue_753_h` and
`header_macro_fallback_include_builtin_h`.

Upon investigation, it seems the root cause is:

* Both headers enable `--clang-macro-fallback`.
* BUT, neither provides a `--clang_macro_fallback_build_dir`.
* So, scratch files are (by default) written directly into the current directory (see https://github.com/flowerhack/rust-bindgen/blob/main/bindgen/ir/context.rs#L2089).
* When these tests simultaneously tried to write to the same file ("-precompile.h.pch"), and clobbered each other.

By creating a temporary directory for `clang_macro_fallback_build_dir` for when `clang-macro-fallback` is passed in,
we ensure the tests remain isolated by writing that file to different temporary directories.

(I think perhaps this issue hasn't come up for most users since running tests on a machine with *lots* of cores may be somewhat uncommon?  But this should fix it for everyone.)